### PR TITLE
refactored a function for readability; expanded tests

### DIFF
--- a/src/main/ml-modules/services/sm-history-document.xqy
+++ b/src/main/ml-modules/services/sm-history-document.xqy
@@ -10,7 +10,5 @@ declare function get(
   $params  as map:map
   ) as document-node()*
 {
-  let $results := history:document-history(map:get($params,"uri"))
-  return
-    xdmp:to-json($results)
+  history:document-history(map:get($params,"uri"))
 };

--- a/src/test/ml-modules/root/test/suites/auditing/document-history.sjs
+++ b/src/test/ml-modules/root/test/suites/auditing/document-history.sjs
@@ -7,7 +7,7 @@ const merging = require('/ext/com.marklogic.smart-mastering/survivorship/merging
 const lib = require('lib/lib.xqy');
 
 const mergedURI = cts.uris(null, "limit=1", cts.collectionQuery(con['MERGED-COLL']));
-const actual = history.documentHistory(mergedURI);
+const actual = history.documentHistory(mergedURI).toObject();
 const activity = actual.activities[0];
 
 let assertions = [];
@@ -25,14 +25,29 @@ xdmp.invokeFunction(
   lib['INVOKE_OPTIONS']
 );
 
-const postRollbackActual = history.documentHistory(mergedURI);
-const postRollbackActivity = postRollbackActual.activities[1];
+const postRollbackActual = history.documentHistory(mergedURI).toObject();
 
-assertions.push(
-  test.assertEqual('rollback', postRollbackActivity.type),
-  test.assertEqual(1, postRollbackActivity.wasDerivedFromUris.length)
-);
+// Match /source/1/doc1.xml and /source/2/doc2.xml
+let origDocRegEx = RegExp('/source/[0-9]/doc[0-9]\.xml');
 
-xdmp.log("assertions: " + assertions.join(","));
+postRollbackActual.activities.forEach(activity => {
+  if (activity.type === 'merge') {
+    assertions.push(
+      test.assertEqual(2, activity.wasDerivedFromUris.length),
+      test.assertEqual(mergedURI, activity.resultUri),
+      test.assertTrue(activity.label.startsWith("merge by"))
+    )
+  } else if (activity.type === 'rollback') {
+    // There will be two of these, one for each of the original docs that got merged
+    assertions.push(
+      test.assertEqual(1, activity.wasDerivedFromUris.length),
+      test.assertEqual(mergedURI, activity.wasDerivedFromUris),
+      test.assertTrue(origDocRegEx.test(activity.resultUri)),
+      test.assertTrue(activity.label.startsWith("rollback by"))
+    )
+  } else {
+    test.fail("activity type should be merge or rollback but is " + activity.type);
+  }
+});
 
 assertions


### PR DESCRIPTION
I discussed the change to the document-history function with @ryanjdew, he agree it might as well return JSON directly. I think the revised code is a lot easier to read. 

Also expanded test of this function. 