### PR TITLE
refactored matcher.xqy to separate public API from interface

### DIFF
--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/constants.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/constants.xqy
@@ -22,3 +22,11 @@ declare variable $MDM-ADMIN := "mdm-admin";
 (: Actions :)
 declare variable $MERGE-ACTION := "merge";
 declare variable $NOTIFY-ACTION := "notify";
+
+(: Notification statuses :)
+declare variable $STATUS-READ := "read";
+declare variable $STATUS-UNREAD := "unread";
+
+(: Predicate for recording match blocks between two documents :)
+declare variable $PRED-MATCH-BLOCK := sem:iri("http://marklogic.com/smart-mastering/match-block");
+

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy
@@ -1,0 +1,97 @@
+xquery version "1.0-ml";
+
+(:
+ : This is an implementation library, not an interface to the Smart Mastering functionality.
+ :)
+
+module namespace blocks-impl = "http://marklogic.com/smart-mastering/blocks-impl";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/ext/com.marklogic.smart-mastering/constants.xqy";
+import module namespace sem = "http://marklogic.com/semantics"
+  at "/MarkLogic/semantics.xqy";
+
+declare option xdmp:mapping "false";
+
+(:
+ : Return a JSON array of any URIs the that input URI is blocked from matching.
+ : @param $uri  input URI
+ : @return JSON array of URIs
+ :)
+declare function blocks-impl:get-blocks($uri as xs:string)
+  as array-node()
+{
+  let $solution :=
+    sem:sparql(
+      "select distinct(?uri as ?blocked) where { ?uri ?isBlocked ?target }",
+      map:new((
+        map:entry("target", sem:iri($uri)),
+        map:entry("isBlocked", $const:PRED-MATCH-BLOCK)
+      )),
+      "map"
+    )
+  return
+    array-node {
+      if (fn:exists($solution)) then
+        $solution ! fn:string(map:get(., "blocked"))
+      else ()
+    }
+};
+
+(:
+ : Block all pairs of URIs from matching.
+ : No return type specified to allow tail call optimization.
+ :
+ : @param uris the sequence of URIs
+ : @return empty sequence
+ :)
+declare function blocks-impl:block-matches($uris as xs:string*)
+{
+  if (fn:empty($uris) or fn:count($uris) = 1) then
+  (: We're done :)
+    ()
+  else
+    let $tail := fn:tail($uris)
+    let $_ := $tail ! blocks-impl:block-match(fn:head($uris), .)
+    return blocks-impl:block-matches($tail)
+};
+
+(:
+ : Prevent the two input URIs from being allowed to match. Helper function for block-matches.
+ :
+ : @param $uri1  First input URI
+ : @param $uri2  Second input URI
+ : @error will throw xs:QName("SM-CANT-BLOCK") if unable to record the block.
+ : @return empty sequence
+ :)
+declare function blocks-impl:block-match($uri1 as xs:string, $uri2 as xs:string)
+as empty-sequence()
+{
+  let $_ :=
+    (: Suppress sem:rdf-insert's return value :)
+    sem:rdf-insert(
+      (
+        sem:triple(sem:iri($uri1), $const:PRED-MATCH-BLOCK, sem:iri($uri2)),
+        sem:triple(sem:iri($uri2), $const:PRED-MATCH-BLOCK, sem:iri($uri1))
+      )
+    )
+  return ()
+};
+
+(:
+ : Clear a match block between the two input URIs.
+ :
+ : @param $uri1  First input URI
+ : @param $uri2  Second input URI
+ :
+ : @error will throw xs:QName("SM-CANT-UNBLOCK") if a block is present, but it cannot be cleared
+ : @return  fn:true if a block was found and cleared; fn:false if no block was found
+ :)
+declare function blocks-impl:allow-match($uri1 as xs:string, $uri2 as xs:string)
+{
+  sem:database-nodes((
+    cts:triples(sem:iri($uri1), $const:PRED-MATCH-BLOCK, sem:iri($uri2)),
+    cts:triples(sem:iri($uri2), $const:PRED-MATCH-BLOCK, sem:iri($uri1))
+  )) ! xdmp:node-delete(.)
+};
+

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
@@ -1,0 +1,295 @@
+xquery version "1.0-ml";
+
+(:
+ : This is an implementation library, not an interface to the Smart Mastering functionality.
+ :)
+
+module namespace match-impl = "http://marklogic.com/smart-mastering/matcher-impl";
+
+import module namespace algorithms = "http://marklogic.com/smart-mastering/algorithms"
+  at  "/ext/com.marklogic.smart-mastering/algorithms/base.xqy";
+import module namespace blocks-impl = "http://marklogic.com/smart-mastering/blocks-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/ext/com.marklogic.smart-mastering/constants.xqy";
+import module namespace json="http://marklogic.com/xdmp/json"
+  at "/MarkLogic/json/json.xqy";
+import module namespace opt-impl = "http://marklogic.com/smart-mastering/options-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy";
+
+declare namespace matcher = "http://marklogic.com/smart-mastering/matcher";
+
+declare option xdmp:mapping "false";
+
+declare function match-impl:find-document-matches-by-options(
+  $document,
+  $options,
+  $start as xs:integer,
+  $page-length as xs:integer,
+  $minimum-threshold,
+  $lock-on-search
+) as element(results)
+{
+  let $options :=
+    if ($options instance of object-node()) then
+      opt-impl:options-from-json($options)
+    else
+      $options
+  let $tuning := $options/matcher:tuning
+  let $property-defs := $options/matcher:property-defs
+  let $thresholds := $options/matcher:thresholds
+  let $scoring := $options/matcher:scoring
+  let $algorithms := algorithms:build-algorithms-map($options/matcher:algorithms)
+  let $query := match-impl:build-query($document, $property-defs, $scoring, $algorithms, $options)
+  let $serialized-query := element boost-query {$query}
+  let $minimum-threshold-combinations :=
+    match-impl:minimum-threshold-combinations($serialized-query, $minimum-threshold)
+  let $match-query :=
+    cts:and-query((
+      cts:collection-query($const:CONTENT-COLL),
+      if (fn:exists(xdmp:node-uri($document))) then
+        cts:not-query(cts:document-query(xdmp:node-uri($document)))
+      else (),
+      cts:or-query(
+        $minimum-threshold-combinations
+      ),
+      let $blocks := blocks-impl:get-blocks(fn:base-uri($document))
+      where fn:exists($blocks/node())
+      return
+        cts:not-query(cts:document-query($blocks/node()))
+    ))
+  let $serialized-match-query :=
+    element match-query {
+      $match-query
+    }
+  let $serialized-match-query-combinations := $serialized-match-query/cts:and-query/cts:or-query//element(*, cts:query)
+  let $reduced-boost := cts:query(
+    element cts:or-query {
+      for $query in $serialized-query/cts:or-query/element(*, cts:query)
+      where fn:not(
+        some $match-combo in $serialized-match-query-combinations
+        satisfies fn:deep-equal($query, $match-combo)
+      )
+      return
+        $query
+    }
+  )
+  let $_lock-on-search :=
+    if ($lock-on-search) then
+      match-impl:lock-on-search($serialized-match-query/cts:and-query/cts:or-query)
+    else ()
+  return (
+    $_lock-on-search,
+    element results {
+      element boost-query {$reduced-boost},
+      $serialized-match-query,
+      match-impl:search(
+        $match-query,
+        $reduced-boost,
+        $minimum-threshold,
+        $thresholds,
+        $start,
+        $page-length,
+        $scoring,
+        $algorithms,
+        $options
+      )
+    }
+  )
+};
+
+declare function match-impl:build-query($document, $property-defs, $scoring, $algorithms, $options)
+{
+  cts:or-query((
+    for $score in $scoring/*
+    let $property-name := $score/@property-name
+    let $property-def := $property-defs/matcher:property[@name = $property-name]
+    where fn:exists($property-def)
+    return
+      let $qname := fn:QName($property-def/@namespace, $property-def/@localname)
+      let $values := $document//*[fn:node-name(.) eq $qname] ! fn:normalize-space(.)[.]
+      where fn:exists($values)
+      return
+        if ($score instance of element(matcher:add)) then
+          cts:element-value-query(
+            $qname,
+            $values,
+            ("case-insensitive"),
+            $score/@weight
+          )
+        else if ($score instance of element(matcher:expand)) then
+          let $algorithm := map:get($algorithms, $score/@algorithm-ref)
+          where fn:exists($algorithm)
+          return algorithms:execute-algorithm($algorithm, $values, $score, $options)
+        else ()
+  (:,
+    for $reduction in $scoring/matcher:reduce
+    let $algorithm := map:get($algorithms, concat($reduction/@algorithm-ref, '-query'))
+    where fn:exists($algorithm)
+    return algorithms:execute-algorithm($algorithm, $document, $reduction, $options):)
+  ))
+};
+
+declare function match-impl:search(
+  $match-query,
+  $boosting-query,
+  $min-threshold,
+  $thresholds,
+  $start,
+  $page-length,
+  $scoring,
+  $algorithms,
+  $options
+) {
+  let $range := $start to ($start + $page-length - 1)
+  let $additional-documents :=
+    for $result at $pos in cts:search(
+      fn:collection(),
+      cts:boost-query(
+        $match-query,
+        $boosting-query
+      ),
+      ("unfiltered", "score-simple")
+    )[fn:position() = $range]
+    let $score := match-impl:simple-score($result)
+    let $result-stub :=
+      element results {
+        attribute uri {xdmp:node-uri($result)},
+        attribute index {$range[fn:position() = $pos]},
+        attribute total {cts:remainder($result)},
+        element matches {
+          cts:walk(
+            $result,
+            cts:or-query((
+              $match-query,
+              $boosting-query
+            )),
+            $cts:node/..
+          )
+        }
+      }
+    let $reduced-score := $score -
+      fn:sum(
+        for $reduction in $scoring/matcher:reduce
+        let $algorithm := map:get($algorithms, $reduction/@algorithm-ref)
+        where fn:exists($algorithm) and algorithms:execute-algorithm($algorithm, $result-stub, $reduction, $options)
+        return $reduction/@weight ! fn:number(.)
+      )
+    where $score ge $min-threshold
+    return
+      element results {
+        $result-stub/@*,
+        attribute score {$reduced-score},
+        attribute threshold {
+          (
+            for $threshold in $thresholds/matcher:threshold
+            where $reduced-score ge fn:number($threshold/@above)
+            order by fn:number($threshold/@above) descending
+            return fn:string($threshold/@label)
+          )[1]
+        },
+        $result-stub/*
+      }
+  return
+    $additional-documents
+};
+
+(:
+ : score-simple gives 8pts per matching term and multiplies the results by 256 (MarkLogic documentation)
+ : this reduces the magnitude of the score
+ :)
+declare function match-impl:simple-score($item) {
+  cts:score($item) div (256 * 8)
+};
+
+declare variable $results-json-config := match-impl:_results-json-config();
+
+declare function match-impl:_results-json-config()
+{
+  let $config := json:config("custom")
+  return (
+    map:put($config, "array-element-names", ("results","matches",xs:QName("cts:option"),xs:QName("cts:text"),xs:QName("cts:element"))),
+    map:put($config, "full-element-names",
+      (xs:QName("cts:query"),
+      xs:QName("cts:and-query"),
+      xs:QName("cts:near-query"),
+      xs:QName("cts:or-query"))
+    ),
+    map:put($config, "json-children", "queries"),
+    map:put($config, "attribute-names",
+      ("name","localname", "namespace", "function",
+      "at", "property-name", "weight", "above", "label","algorithm-ref")
+    ),
+    $config
+  )
+};
+
+declare function match-impl:minimum-threshold-combinations($query-results, $threshold)
+{
+  let $weighted-queries :=
+    for $query in ($query-results//element(*,cts:query) except $query-results//(cts:and-query|cts:or-query))
+    let $weight := $query/@weight ! fn:number(.)
+    where fn:empty($weight) or $weight gt 0
+    order by $weight descending empty least
+    return $query
+  let $queries-ge-threshold := $weighted-queries[@weight][@weight ge $threshold]
+  let $queries-lt-threshold := $weighted-queries except $queries-ge-threshold
+  return (
+    $queries-ge-threshold ! cts:query(.),
+    match-impl:filter-for-required-queries($queries-lt-threshold, 0, $threshold, ())
+  )
+};
+
+declare function match-impl:filter-for-required-queries(
+  $remaining-queries,
+  $combined-weight,
+  $threshold,
+  $accumulated-queries
+) {
+  if ($threshold eq 0 or $combined-weight ge $threshold) then
+    cts:and-query(
+      $accumulated-queries ! cts:query(.)
+    )
+  else
+    for $query at $pos in $remaining-queries
+    let $query-weight := fn:head(($query/@weight ! fn:number(.), 1))
+    let $new-combined-weight := $combined-weight + $query-weight
+    let $last-accumulated := fn:head(fn:reverse($accumulated-queries))
+    let $last-accumulated-weight := fn:min(($last-accumulated/@weight/fn:number(),1))
+    let $accumulated-queries :=
+      if (fn:exists($last-accumulated) and
+        ($new-combined-weight - $last-accumulated-weight) ge $threshold) then
+        $accumulated-queries except $last-accumulated
+      else
+        $accumulated-queries
+    return
+      match-impl:filter-for-required-queries(
+        fn:subsequence($remaining-queries, $pos + 1),
+        $new-combined-weight,
+        $threshold,
+        ($accumulated-queries, $query)
+      )
+};
+
+declare function match-impl:lock-on-search($query-results)
+  as empty-sequence()
+{
+  let $required-queries := $query-results/element(*,cts:query)
+  for $required-query in $required-queries
+  let $lock-uri := "/com.marklogic.smart-mastering/query-lock/"||
+  fn:normalize-unicode(
+    fn:normalize-space(fn:lower-case(fn:string($required-query)))
+  )
+  return
+    fn:function-lookup(xs:QName("xdmp:lock-for-update"),1)($lock-uri)
+};
+
+declare function match-impl:results-to-json($results-xml)
+  as object-node()?
+{
+  if (fn:exists($results-xml)) then
+    xdmp:to-json(
+      json:transform-to-json-object($results-xml, $results-json-config)
+    )
+  else ()
+};

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy
@@ -4,7 +4,7 @@ xquery version "1.0-ml";
  : This is an implementation library, not an interface to the Smart Mastering functionality.
  :)
 
-module namespace not-impl = "http://marklogic.com/smart-mastering/notification-impl";
+module namespace notify-impl = "http://marklogic.com/smart-mastering/notification-impl";
 
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/ext/com.marklogic.smart-mastering/constants.xqy";
@@ -15,13 +15,13 @@ declare namespace sm = "http://marklogic.com/smart-mastering";
 
 declare option xdmp:mapping "false";
 
-declare function not-impl:save-match-notification(
+declare function notify-impl:save-match-notification(
   $threshold-label as xs:string,
   $uris as xs:string*
 )
 {
   let $existing-notification :=
-    not-impl:get-existing-match-notification(
+    notify-impl:get-existing-match-notification(
       $threshold-label,
       $uris
     )
@@ -68,7 +68,7 @@ declare function not-impl:save-match-notification(
       )
 };
 
-declare function not-impl:get-existing-match-notification(
+declare function notify-impl:get-existing-match-notification(
   $threshold-label as xs:string,
   $uris as xs:string*
 ) as element(sm:notification)*
@@ -91,7 +91,7 @@ declare function not-impl:get-existing-match-notification(
  : Delete the specified notification
  : TODO: do we want to add any provenance tracking to this?
  :)
-declare function not-impl:delete-notification($uri as xs:string)
+declare function notify-impl:delete-notification($uri as xs:string)
 {
   xdmp:document-delete($uri)
 };
@@ -99,7 +99,7 @@ declare function not-impl:delete-notification($uri as xs:string)
 (:
  : Translate a notifcation into JSON.
  :)
-declare function not-impl:notification-to-json($notification as element(sm:notification))
+declare function notify-impl:notification-to-json($notification as element(sm:notification))
   as object-node()
 {
   object-node {
@@ -131,7 +131,7 @@ declare function not-impl:notification-to-json($notification as element(sm:notif
 (:
  : Paged retrieval of notifications
  :)
-declare function not-impl:get-notifications-as-xml($start as xs:int, $end as xs:int)
+declare function notify-impl:get-notifications-as-xml($start as xs:int, $end as xs:int)
 as element(sm:notification)*
 {
   (fn:collection($const:NOTIFICATION-COLL)[$start to $end])/sm:notification
@@ -140,18 +140,18 @@ as element(sm:notification)*
 (:
  : Paged retrieval of notifications
  :)
-declare function not-impl:get-notifications-as-json($start as xs:int, $end as xs:int)
+declare function notify-impl:get-notifications-as-json($start as xs:int, $end as xs:int)
 as array-node()
 {
   array-node {
-    not-impl:get-notifications-as-xml($start, $end) ! not-impl:notification-to-json(.)
+    notify-impl:get-notifications-as-xml($start, $end) ! notify-impl:notification-to-json(.)
   }
 };
 
 (:
  : Return a count of all notifications
  :)
-declare function not-impl:count-notifications()
+declare function notify-impl:count-notifications()
 as xs:int
 {
   xdmp:estimate(fn:collection($const:NOTIFICATION-COLL))
@@ -160,7 +160,7 @@ as xs:int
 (:
  : Return a count of unread notifications
  :)
-declare function not-impl:count-unread-notifications()
+declare function notify-impl:count-unread-notifications()
 as xs:int
 {
   xdmp:estimate(
@@ -170,7 +170,7 @@ as xs:int
   )
 };
 
-declare function not-impl:update-notification-status(
+declare function notify-impl:update-notification-status(
   $uri as xs:string+,
   $status as xs:string
 )

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy
@@ -1,0 +1,182 @@
+xquery version "1.0-ml";
+
+(:
+ : This is an implementation library, not an interface to the Smart Mastering functionality.
+ :)
+
+module namespace not-impl = "http://marklogic.com/smart-mastering/notification-impl";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/ext/com.marklogic.smart-mastering/constants.xqy";
+import module namespace json="http://marklogic.com/xdmp/json"
+  at "/MarkLogic/json/json.xqy";
+
+declare namespace sm = "http://marklogic.com/smart-mastering";
+
+declare option xdmp:mapping "false";
+
+declare function not-impl:save-match-notification(
+  $threshold-label as xs:string,
+  $uris as xs:string*
+)
+{
+  let $existing-notification :=
+    not-impl:get-existing-match-notification(
+      $threshold-label,
+      $uris
+    )
+  let $new-notification :=
+    element sm:notification {
+      element sm:meta {
+        element sm:dateTime {fn:current-dateTime()},
+        element sm:user {xdmp:get-current-user()},
+        element sm:status { $const:STATUS-UNREAD }
+      },
+      element sm:threshold-label {$threshold-label},
+      element sm:document-uris {
+        let $distinct-uris :=
+          fn:distinct-values((
+            $uris,
+            $existing-notification
+            /sm:document-uris
+              /sm:document-uri ! fn:string(.)
+          ))
+        for $uri in $distinct-uris
+        return
+          element sm:document-uri {
+            $uri
+          }
+      }
+    }
+  return
+    if (fn:exists($existing-notification)) then (
+      xdmp:node-replace(fn:head($existing-notification), $new-notification),
+      for $extra-doc in fn:tail($existing-notification)
+      return
+        xdmp:document-delete(xdmp:node-uri($extra-doc))
+    ) else
+      xdmp:document-insert(
+        "/com.marklogic.smart-mastering/matcher/notifications/" ||
+        sem:uuid-string() || ".xml",
+        $new-notification,
+        (
+          xdmp:default-permissions(),
+          xdmp:permission($const:MDM-USER, "read"),
+          xdmp:permission($const:MDM-USER, "update")
+        ),
+        $const:NOTIFICATION-COLL
+      )
+};
+
+declare function not-impl:get-existing-match-notification(
+  $threshold-label as xs:string,
+  $uris as xs:string*
+) as element(sm:notification)*
+{
+  cts:search(fn:collection()/sm:notification,
+    cts:and-query((
+      cts:element-value-query(
+        xs:QName("sm:threshold-label"),
+        $threshold-label
+      ),
+      cts:element-value-query(
+        xs:QName("sm:document-uri"),
+        $uris
+      )
+    ))
+  )
+};
+
+(:
+ : Delete the specified notification
+ : TODO: do we want to add any provenance tracking to this?
+ :)
+declare function not-impl:delete-notification($uri as xs:string)
+{
+  xdmp:document-delete($uri)
+};
+
+(:
+ : Translate a notifcation into JSON.
+ :)
+declare function not-impl:notification-to-json($notification as element(sm:notification))
+  as object-node()
+{
+  object-node {
+    "meta": object-node {
+      "dateTime": $notification/sm:meta/sm:dateTime/fn:string(),
+      "user": $notification/sm:meta/sm:user/fn:string(),
+      "uri": fn:base-uri($notification),
+      "status": $notification/sm:meta/sm:status/fn:string()
+    },
+    "thresholdLabel": $notification/sm:threshold-label/fn:string(),
+    "uris": array-node {
+      for $uri in $notification/sm:document-uris/sm:document-uri
+      return
+        object-node { "uri": $uri/fn:string() }
+    },
+    "names": xdmp:to-json(
+      let $o := json:object()
+      let $_ :=
+        for $uri in $notification/sm:document-uris/sm:document-uri
+        let $doc := fn:doc($uri)
+        let $name := $doc//*:PersonGivenName || " " || $doc//*:PersonSurName
+        return
+          map:put($o, $uri, $name)
+      return $o
+    )
+  }
+};
+
+(:
+ : Paged retrieval of notifications
+ :)
+declare function not-impl:get-notifications-as-xml($start as xs:int, $end as xs:int)
+as element(sm:notification)*
+{
+  (fn:collection($const:NOTIFICATION-COLL)[$start to $end])/sm:notification
+};
+
+(:
+ : Paged retrieval of notifications
+ :)
+declare function not-impl:get-notifications-as-json($start as xs:int, $end as xs:int)
+as array-node()
+{
+  array-node {
+    not-impl:get-notifications-as-xml($start, $end) ! not-impl:notification-to-json(.)
+  }
+};
+
+(:
+ : Return a count of all notifications
+ :)
+declare function not-impl:count-notifications()
+as xs:int
+{
+  xdmp:estimate(fn:collection($const:NOTIFICATION-COLL))
+};
+
+(:
+ : Return a count of unread notifications
+ :)
+declare function not-impl:count-unread-notifications()
+as xs:int
+{
+  xdmp:estimate(
+    cts:search(
+      fn:collection($const:NOTIFICATION-COLL),
+      cts:element-value-query(xs:QName("sm:status"), $const:STATUS-UNREAD))
+  )
+};
+
+declare function not-impl:update-notification-status(
+  $uri as xs:string+,
+  $status as xs:string
+)
+{
+  xdmp:node-replace(
+    fn:doc($uri)/sm:notification/sm:meta/sm:status,
+    element sm:status { $status }
+  )
+};

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy
@@ -1,0 +1,134 @@
+xquery version "1.0-ml";
+
+(:
+ : This is an implementation library, not an interface to the Smart Mastering functionality.
+ :)
+
+module namespace opt-impl = "http://marklogic.com/smart-mastering/options-impl";
+
+import module namespace algorithms = "http://marklogic.com/smart-mastering/algorithms"
+  at "/ext/com.marklogic.smart-mastering/algorithms/base.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/ext/com.marklogic.smart-mastering/constants.xqy";
+import module namespace json="http://marklogic.com/xdmp/json"
+  at "/MarkLogic/json/json.xqy";
+
+declare namespace matcher = "http://marklogic.com/smart-mastering/matcher";
+
+declare option xdmp:mapping "false";
+
+declare variable $ALGORITHM-OPTIONS-DIR := "/com.marklogic.smart-mastering/options/algorithms/";
+
+declare variable $options-json-config := opt-impl:_options-json-config();
+
+declare function opt-impl:_options-json-config()
+{
+  let $config := json:config("custom")
+  return (
+    map:put($config, "array-element-names",
+      ("algorithm","threshold","scoring","property", "reduce", "add", "expand","results")),
+    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/matcher"),
+    map:put($config, "element-namespace-prefix", "matcher"),
+    map:put($config, "attribute-names",
+      ("name","localname", "namespace", "function",
+      "at", "property-name", "weight", "above", "label","algorithm-ref")
+    ),
+    $config
+  )
+};
+
+declare function opt-impl:get-option-names-as-xml()
+{
+  let $options := cts:uris('', (), cts:collection-query($const:MATCH-OPTIONS-COLL))
+  let $option-names := $options !
+    fn:replace(
+      fn:replace(., $ALGORITHM-OPTIONS-DIR, ""),
+      ".xml", ""
+    )
+  return
+    element matcher:options {
+      $option-names ! element matcher:option { . }
+    }
+};
+
+declare function opt-impl:get-option-names-as-json()
+  as object-node()?
+{
+  opt-impl:option-names-to-json(
+    opt-impl:get-option-names-as-xml()
+  )
+};
+
+declare variable $option-names-json-config := opt-impl:option-names-json-config();
+
+declare function opt-impl:option-names-json-config()
+{
+  let $config := json:config("custom")
+  return (
+    map:put($config, "array-element-names", "option"),
+    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/matcher"),
+    map:put($config, "element-namespace-prefix", "matcher"),
+    $config
+  )
+};
+
+declare function opt-impl:option-names-to-json($options-xml)
+  as object-node()?
+{
+  if (fn:exists($options-xml)) then
+    xdmp:to-json(
+      json:transform-to-json-object($options-xml, $option-names-json-config)
+    )/node()
+  else ()
+};
+
+declare function opt-impl:get-options-as-xml($options-name as xs:string)
+{
+  fn:doc($ALGORITHM-OPTIONS-DIR||$options-name||".xml")/matcher:options
+};
+
+declare function opt-impl:get-options-as-json($options-name as xs:string)
+  as object-node()?
+{
+  opt-impl:options-to-json(
+    fn:doc($ALGORITHM-OPTIONS-DIR||$options-name||".xml")/matcher:options
+  )
+};
+
+declare function opt-impl:save-options(
+  $name as xs:string,
+  $options as node()
+)
+{
+  let $options :=
+    if ($options instance of object-node()) then
+      opt-impl:options-from-json($options)
+    else
+      $options
+  return (
+    algorithms:setup-algorithms($options/(self::*:options|*:options)),
+    xdmp:document-insert(
+      $ALGORITHM-OPTIONS-DIR||$name||".xml",
+      $options,
+      (xdmp:permission($const:MDM-ADMIN, "update"), xdmp:permission($const:MDM-USER, "read")),
+      ($const:OPTIONS-COLL, $const:MATCH-OPTIONS-COLL, $const:ALGORITHM-COLL)
+    )
+  )
+};
+
+(: Convert JSON match options to XML :)
+declare function opt-impl:options-from-json($options-json)
+{
+  json:transform-from-json($options-json, $opt-impl:options-json-config)
+};
+
+declare function opt-impl:options-to-json($options-xml as element(matcher:options)?)
+  as object-node()?
+{
+  if (fn:exists($options-xml)) then
+    xdmp:to-json(
+      json:transform-to-json-object($options-xml, $opt-impl:options-json-config)
+    )/node()
+  else ()
+};
+

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher.xqy
@@ -2,26 +2,18 @@ xquery version "1.0-ml";
 
 module namespace matcher = "http://marklogic.com/smart-mastering/matcher";
 
-import module namespace algorithms = "http://marklogic.com/smart-mastering/algorithms"
-  at  "algorithms/base.xqy";
-import module namespace json="http://marklogic.com/xdmp/json"
-  at "/MarkLogic/json/json.xqy";
-import module namespace sem = "http://marklogic.com/semantics"
-  at "/MarkLogic/semantics.xqy";
-import module namespace const = "http://marklogic.com/smart-mastering/constants"
-  at "/ext/com.marklogic.smart-mastering/constants.xqy";
+import module namespace blocks-impl = "http://marklogic.com/smart-mastering/blocks-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy";
+import module namespace match-impl = "http://marklogic.com/smart-mastering/matcher-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy";
+import module namespace not-impl = "http://marklogic.com/smart-mastering/notification-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy";
+import module namespace opt-impl = "http://marklogic.com/smart-mastering/options-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy";
 
 declare namespace sm = "http://marklogic.com/smart-mastering";
 
 declare option xdmp:mapping "false";
-
-declare variable $ALGORITHM-OPTIONS-DIR := "/com.marklogic.smart-mastering/options/algorithms/";
-
-(: Predicate for recording match blocks between two documents :)
-declare variable $PRED-MATCH-BLOCK := sem:iri("http://marklogic.com/smart-mastering/match-block");
-
-declare variable $STATUS-READ := "read";
-declare variable $STATUS-UNREAD := "unread";
 
 (:
 
@@ -79,11 +71,13 @@ Example matcher options:
 :)
 
 declare function matcher:find-document-matches-by-options-name($document, $options-name)
+  as element(results)
 {
-  matcher:find-document-matches-by-options($document, matcher:get-options($options-name))
+  matcher:find-document-matches-by-options($document, matcher:get-options-as-xml($options-name))
 };
 
 declare function matcher:find-document-matches-by-options($document, $options)
+  as element(results)
 {
   matcher:find-document-matches-by-options(
     $document,
@@ -102,8 +96,9 @@ declare function matcher:find-document-matches-by-options(
   $options,
   $start,
   $page-length
-) {
-  matcher:find-document-matches-by-options(
+) as element(results)
+{
+  match-impl:find-document-matches-by-options(
     $document,
     $options,
     $start,
@@ -120,432 +115,49 @@ declare function matcher:find-document-matches-by-options(
   $page-length as xs:integer,
   $minimum-threshold,
   $lock-on-search
-) {
-  let $options :=
-    if ($options instance of object-node()) then
-      matcher:options-from-json($options)
-    else
-      $options
-  let $tuning := $options/matcher:tuning
-  let $property-defs := $options/matcher:property-defs
-  let $thresholds := $options/matcher:thresholds
-  let $scoring := $options/matcher:scoring
-  let $algorithms := algorithms:build-algorithms-map($options/matcher:algorithms)
-  let $query := matcher:build-query($document, $property-defs, $scoring, $algorithms, $options)
-  let $serialized-query := element boost-query {$query}
-  let $minimum-threshold-combinations :=
-    matcher:minimum-threshold-combinations($serialized-query, $minimum-threshold)
-  let $match-query :=
-    cts:and-query((
-        cts:collection-query($const:CONTENT-COLL),
-        if (fn:exists(xdmp:node-uri($document))) then
-          cts:not-query(cts:document-query(xdmp:node-uri($document)))
-        else (),
-        cts:or-query(
-          $minimum-threshold-combinations
-        ),
-        let $blocks := matcher:get-blocks(fn:base-uri($document))
-        where fn:exists($blocks/node())
-        return
-          cts:not-query(cts:document-query($blocks/node()))
-    ))
-  let $serialized-match-query :=
-    element match-query {
-      $match-query
-    }
-  let $serialized-match-query-combinations := $serialized-match-query/cts:and-query/cts:or-query//element(*, cts:query)
-  let $reduced-boost := cts:query(
-    element cts:or-query {
-      for $query in $serialized-query/cts:or-query/element(*, cts:query)
-      where fn:not(
-        some $match-combo in $serialized-match-query-combinations
-        satisfies fn:deep-equal($query, $match-combo)
-      )
-      return
-        $query
-    }
-  )
-  let $_lock-on-search :=
-    if ($lock-on-search) then
-      matcher:lock-on-search($serialized-match-query/cts:and-query/cts:or-query)
-    else ()
-  return (
-    $_lock-on-search,
-    element results {
-      element boost-query {$reduced-boost},
-      $serialized-match-query,
-      matcher:search(
-        $match-query,
-        $reduced-boost,
-        $minimum-threshold,
-        $thresholds,
-        $start,
-        $page-length,
-        $scoring,
-        $algorithms,
-        $options
-      )
-    }
-  )
-};
-
-declare function matcher:build-query($document, $property-defs, $scoring, $algorithms, $options)
+) as element(results)
 {
-  cts:or-query((
-    for $score in $scoring/*
-    let $property-name := $score/@property-name
-    let $property-def := $property-defs/matcher:property[@name = $property-name]
-    where fn:exists($property-def)
-    return
-      let $qname := fn:QName($property-def/@namespace, $property-def/@localname)
-      let $values := $document//*[fn:node-name(.) eq $qname] ! fn:normalize-space(.)[.]
-      where fn:exists($values)
-      return
-        if ($score instance of element(matcher:add)) then
-          cts:element-value-query(
-            $qname,
-            $values,
-            ("case-insensitive"),
-            $score/@weight
-          )
-        else if ($score instance of element(matcher:expand)) then
-          let $algorithm := map:get($algorithms, $score/@algorithm-ref)
-          where fn:exists($algorithm)
-          return algorithms:execute-algorithm($algorithm, $values, $score, $options)
-        else ()
-    (:,
-    for $reduction in $scoring/matcher:reduce
-    let $algorithm := map:get($algorithms, concat($reduction/@algorithm-ref, '-query'))
-    where fn:exists($algorithm)
-    return algorithms:execute-algorithm($algorithm, $document, $reduction, $options):)
-  ))
+  match-impl:find-document-matches-by-options($document, $options, $start, $page-length, $minimum-threshold, $lock-on-search)
 };
 
-declare function matcher:search(
-  $match-query,
-  $boosting-query,
-  $min-threshold,
-  $thresholds,
-  $start,
-  $page-length,
-  $scoring,
-  $algorithms,
-  $options
-) {
-  let $range := $start to ($start + $page-length - 1)
-  let $additional-documents :=
-    for $result at $pos in cts:search(
-                            fn:collection(),
-                            cts:boost-query(
-                              $match-query,
-                              $boosting-query
-                            ),
-                            ("unfiltered", "score-simple")
-                          )[fn:position() = $range]
-    let $score := matcher:simple-score($result)
-    let $result-stub :=
-      element results {
-        attribute uri {xdmp:node-uri($result)},
-        attribute index {$range[fn:position() = $pos]},
-        attribute total {cts:remainder($result)},
-        element matches {
-          cts:walk(
-            $result,
-            cts:or-query((
-              $match-query,
-              $boosting-query
-            )),
-            $cts:node/..
-          )
-        }
-      }
-    let $reduced-score := $score -
-      fn:sum(
-        for $reduction in $scoring/matcher:reduce
-        let $algorithm := map:get($algorithms, $reduction/@algorithm-ref)
-        where fn:exists($algorithm) and algorithms:execute-algorithm($algorithm, $result-stub, $reduction, $options)
-        return $reduction/@weight ! fn:number(.)
-      )
-    where $score ge $min-threshold
-    return
-      element results {
-        $result-stub/@*,
-        attribute score {$reduced-score},
-        attribute threshold {
-          (
-            for $threshold in $thresholds/matcher:threshold
-            where $reduced-score ge fn:number($threshold/@above)
-            order by fn:number($threshold/@above) descending
-            return fn:string($threshold/@label)
-          )[1]
-        },
-        $result-stub/*
-      }
-  return
-      $additional-documents
-};
-
-declare function matcher:get-option-names()
+declare function matcher:get-option-names-as-xml()
+  as element(matcher:options)
 {
-  let $options := cts:uris('', (), cts:collection-query($const:MATCH-OPTIONS-COLL))
-  let $option-names := $options ! fn:replace(
-    fn:replace(., $ALGORITHM-OPTIONS-DIR, ""),
-    ".xml", ""
-  )
-  return
-    element matcher:options {
-      for $name in $option-names
-      return
-        element matcher:option { $name }
-    }
+  opt-impl:get-option-names-as-xml()
 };
 
-declare variable $option-names-json-config := matcher:_option-names-json-config();
-
-declare function matcher:_option-names-json-config()
+declare function matcher:get-option-names-as-json()
+  as object-node()?
 {
-  let $config := json:config("custom")
-  return (
-    map:put($config, "array-element-names", "option"),
-    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/matcher"),
-    map:put($config, "element-namespace-prefix", "matcher"),
-    $config
-  )
+  opt-impl:get-option-names-as-json()
 };
 
-declare function matcher:option-names-to-json($options-xml)
+declare function matcher:get-options-as-xml($options-name as xs:string)
+  as element(matcher:options)?
 {
-  xdmp:to-json(
-    json:transform-to-json-object($options-xml, $option-names-json-config)
-  )
+  opt-impl:get-options-as-xml($options-name)
 };
 
-declare function matcher:get-options($options-name)
+declare function matcher:get-options-as-json($options-name as xs:string)
+  as object-node()?
 {
-  fn:doc($ALGORITHM-OPTIONS-DIR||$options-name||".xml")/matcher:options
-};
-
-(:
- : score-simple gives 8pts per matching term and multiplies the results by 256 (MarkLogic documentation)
- : this reduces the magnitude of the score
- :)
-declare function matcher:simple-score($item) {
-  cts:score($item) div (256 * 8)
+  opt-impl:get-options-as-json($options-name)
 };
 
 declare function matcher:save-options(
   $name as xs:string,
   $options as node()
-)
+) as empty-sequence()
 {
-  algorithms:setup-algorithms($options/(self::*:options|*:options)),
-  xdmp:document-insert(
-    $ALGORITHM-OPTIONS-DIR||$name||".xml",
-    $options,
-    (xdmp:permission($const:MDM-ADMIN, "update"), xdmp:permission($const:MDM-USER, "read")),
-    ($const:OPTIONS-COLL, $const:MATCH-OPTIONS-COLL, $const:ALGORITHM-COLL)
-  )
+  opt-impl:save-options($name, $options)
 };
-
-declare function matcher:save-match-notification(
-  $threshold-label as xs:string,
-  $uris as xs:string*
-) {
-  let $existing-notification :=
-    matcher:get-existing-match-notification(
-      $threshold-label,
-      $uris
-    )
-  let $new-notification :=
-    element sm:notification {
-      element sm:meta {
-        element sm:dateTime {fn:current-dateTime()},
-        element sm:user {xdmp:get-current-user()},
-        element sm:status { $STATUS-UNREAD }
-      },
-      element sm:threshold-label {$threshold-label},
-      element sm:document-uris {
-        let $distinct-uris :=
-          fn:distinct-values((
-            $uris,
-            $existing-notification
-              /sm:document-uris
-              /sm:document-uri ! fn:string(.)
-          ))
-        for $uri in $distinct-uris
-        return
-          element sm:document-uri {
-            $uri
-          }
-      }
-    }
-  return
-    if (fn:exists($existing-notification)) then (
-      xdmp:node-replace(fn:head($existing-notification), $new-notification),
-      for $extra-doc in fn:tail($existing-notification)
-      return
-        xdmp:document-delete(xdmp:node-uri($extra-doc))
-    ) else
-      xdmp:document-insert(
-        "/com.marklogic.smart-mastering/matcher/notifications/" ||
-        sem:uuid-string() || ".xml",
-        $new-notification,
-        (
-          xdmp:default-permissions(),
-          xdmp:permission($const:MDM-USER, "read"),
-          xdmp:permission($const:MDM-USER, "update")
-        ),
-        $const:NOTIFICATION-COLL
-      )
-};
-
-declare function matcher:get-existing-match-notification(
-  $threshold-label as xs:string,
-  $uris as xs:string*
-) as element(sm:notification)*
-{
-  cts:search(fn:collection()/sm:notification,
-    cts:and-query((
-      cts:element-value-query(
-        xs:QName("sm:threshold-label"),
-        $threshold-label
-      ),
-      cts:element-value-query(
-        xs:QName("sm:document-uri"),
-        $uris
-      )
-    ))
-  )
-};
-
-(:
- : Delete the specified notification
- : TODO: do we want to add any provenance tracking to this?
- :)
-declare function matcher:delete-notification($uri as xs:string)
-{
-  xdmp:document-delete($uri)
-};
-
-declare variable $options-json-config := matcher:_options-json-config();
-
-declare function matcher:_options-json-config()
-{
-  let $config := json:config("custom")
-  return (
-    map:put($config, "array-element-names",
-             ("algorithm","threshold","scoring","property", "reduce", "add", "expand","results")),
-    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/matcher"),
-    map:put($config, "element-namespace-prefix", "matcher"),
-    map:put($config, "attribute-names",
-      ("name","localname", "namespace", "function",
-        "at", "property-name", "weight", "above", "label","algorithm-ref")
-    ),
-    $config
-  )
-};
-
-declare function matcher:options-to-json($options-xml)
-{
-  xdmp:to-json(
-    json:transform-to-json-object($options-xml, $options-json-config)
-  )
-};
-
-(: Convert JSON match options to XML :)
-declare function matcher:options-from-json($options-json)
-{
-  json:transform-from-json($options-json, $options-json-config)
-};
-
-declare variable $results-json-config := matcher:_results-json-config();
 
 declare function matcher:results-to-json($results-xml)
+  as object-node()?
 {
-  xdmp:to-json(
-    json:transform-to-json-object($results-xml, $results-json-config)
-  )
+  match-impl:results-to-json($results-xml)
 };
 
-declare function matcher:_results-json-config()
-{
-  let $config := json:config("custom")
-  return (
-    map:put($config, "array-element-names", ("results","matches",xs:QName("cts:option"),xs:QName("cts:text"),xs:QName("cts:element"))),
-    map:put($config, "full-element-names",
-      (xs:QName("cts:query"),
-       xs:QName("cts:and-query"),
-       xs:QName("cts:near-query"),
-       xs:QName("cts:or-query"))
-    ),
-    map:put($config, "json-children", "queries"),
-    map:put($config, "attribute-names",
-      ("name","localname", "namespace", "function",
-       "at", "property-name", "weight", "above", "label","algorithm-ref")
-    ),
-    $config
-  )
-};
-
-
-declare function matcher:minimum-threshold-combinations($query-results, $threshold)
-{
-  let $weighted-queries :=
-    for $query in ($query-results//element(*,cts:query) except $query-results//(cts:and-query|cts:or-query))
-    let $weight := $query/@weight ! fn:number(.)
-    where fn:empty($weight) or $weight gt 0
-    order by $weight descending empty least
-    return $query
-  let $queries-ge-threshold := $weighted-queries[@weight][@weight ge $threshold]
-  let $queries-lt-threshold := $weighted-queries except $queries-ge-threshold
-  return (
-    $queries-ge-threshold ! cts:query(.),
-    matcher:filter-for-required-queries($queries-lt-threshold, 0, $threshold, ())
-  )
-};
-
-declare function matcher:filter-for-required-queries(
-  $remaining-queries,
-  $combined-weight,
-  $threshold,
-  $accumulated-queries
-) {
-  if ($threshold eq 0 or $combined-weight ge $threshold) then
-    cts:and-query(
-      $accumulated-queries ! cts:query(.)
-    )
-  else
-    for $query at $pos in $remaining-queries
-    let $query-weight := fn:head(($query/@weight ! fn:number(.), 1))
-    let $new-combined-weight := $combined-weight + $query-weight
-    let $last-accumulated := fn:head(fn:reverse($accumulated-queries))
-    let $last-accumulated-weight := fn:min(($last-accumulated/@weight/fn:number(),1))
-    let $accumulated-queries :=
-      if (fn:exists($last-accumulated) and
-        ($new-combined-weight - $last-accumulated-weight) ge $threshold) then
-        $accumulated-queries except $last-accumulated
-      else
-        $accumulated-queries
-    return
-      matcher:filter-for-required-queries(
-        fn:subsequence($remaining-queries, $pos + 1),
-        $new-combined-weight,
-        $threshold,
-        ($accumulated-queries, $query)
-      )
-};
-
-declare function matcher:lock-on-search($query-results)
-{
-  let $required-queries := $query-results/element(*,cts:query)
-  for $required-query in $required-queries
-  let $lock-uri := "/com.marklogic.smart-mastering/query-lock/"||
-      fn:normalize-unicode(
-        fn:normalize-space(fn:lower-case(fn:string($required-query)))
-      )
-  return
-    fn:function-lookup(xs:QName("xdmp:lock-for-update"),1)($lock-uri)
-};
 
 (:
  : Return a JSON array of any URIs the that input URI is blocked from matching.
@@ -555,43 +167,7 @@ declare function matcher:lock-on-search($query-results)
 declare function matcher:get-blocks($uri as xs:string)
   as array-node()
 {
-  let $solution :=
-    sem:sparql(
-      "select distinct(?uri as ?blocked) where { ?uri ?isBlocked ?target }",
-      map:new((
-        map:entry("target", sem:iri($uri)),
-        map:entry("isBlocked", $PRED-MATCH-BLOCK)
-      )),
-      "map"
-    )
-  return
-    array-node {
-      if (fn:exists($solution)) then
-        $solution ! fn:string(map:get(., "blocked"))
-      else ()
-    }
-};
-
-(:
- : Prevent the two input URIs from being allowed to match.
- :
- : @param $uri1  First input URI
- : @param $uri2  Second input URI
- : @error will throw xs:QName("SM-CANT-BLOCK") if unable to record the block.
- : @return empty sequence
- :)
-declare function matcher:block-match($uri1 as xs:string, $uri2 as xs:string)
-  as empty-sequence()
-{
-  let $_ :=
-    (: Suppress sem:rdf-insert's return value :)
-    sem:rdf-insert(
-      (
-        sem:triple(sem:iri($uri1), $PRED-MATCH-BLOCK, sem:iri($uri2)),
-        sem:triple(sem:iri($uri2), $PRED-MATCH-BLOCK, sem:iri($uri1))
-      )
-    )
-  return ()
+  blocks-impl:get-blocks($uri)
 };
 
 (:
@@ -607,13 +183,7 @@ declare function matcher:block-match($uri1 as xs:string, $uri2 as xs:string)
  :)
 declare function matcher:block-matches($uris as xs:string*)
 {
-  if (fn:empty($uris) or fn:count($uris) = 1) then
-    (: We're done :)
-    ()
-  else
-    let $tail := fn:tail($uris)
-    let $_ := $tail ! matcher:block-match(fn:head($uris), .)
-    return matcher:block-matches($tail)
+  blocks-impl:block-matches($uris)
 };
 
 (:
@@ -627,51 +197,25 @@ declare function matcher:block-matches($uris as xs:string*)
  :)
 declare function matcher:allow-match($uri1 as xs:string, $uri2 as xs:string)
 {
-  sem:database-nodes((
-    cts:triples(sem:iri($uri1), $PRED-MATCH-BLOCK, sem:iri($uri2)),
-    cts:triples(sem:iri($uri2), $PRED-MATCH-BLOCK, sem:iri($uri1))
-  )) ! xdmp:node-delete(.)
-};
-
-(:
- : Translate a notifcation into JSON.
- :)
-declare function matcher:notification-to-json($notification as element(sm:notification))
-as object-node()
-{
-  object-node {
-    "meta": object-node {
-      "dateTime": $notification/sm:meta/sm:dateTime/fn:string(),
-      "user": $notification/sm:meta/sm:user/fn:string(),
-      "uri": fn:base-uri($notification),
-      "status": $notification/sm:meta/sm:status/fn:string()
-    },
-    "thresholdLabel": $notification/sm:threshold-label/fn:string(),
-    "uris": array-node {
-      for $uri in $notification/sm:document-uris/sm:document-uri
-      return
-        object-node { "uri": $uri/fn:string() }
-    },
-    "names": xdmp:to-json(
-      let $o := json:object()
-      let $_ :=
-        for $uri in $notification/sm:document-uris/sm:document-uri
-        let $doc := fn:doc($uri)
-        let $name := $doc//*:PersonGivenName || " " || $doc//*:PersonSurName
-        return
-          map:put($o, $uri, $name)
-      return $o
-    )
-  }
+  blocks-impl:allow-match($uri1, $uri2)
 };
 
 (:
  : Paged retrieval of notifications
  :)
-declare function matcher:get-notifications($start, $end)
-as element(sm:notification)*
+declare function matcher:get-notifications-as-xml($start as xs:int, $end as xs:int)
+  as element(sm:notification)*
 {
-  (fn:collection($const:NOTIFICATION-COLL)[$start to $end])/sm:notification
+  not-impl:get-notifications-as-xml($start, $end)
+};
+
+(:
+ : Paged retrieval of notifications
+ :)
+declare function matcher:get-notifications-as-json($start as xs:int, $end as xs:int)
+  as array-node()
+{
+  not-impl:get-notifications-as-json($start, $end)
 };
 
 (:
@@ -680,7 +224,7 @@ as element(sm:notification)*
 declare function matcher:count-notifications()
 as xs:int
 {
-  xdmp:estimate(fn:collection($const:NOTIFICATION-COLL))
+  not-impl:count-notifications()
 };
 
 (:
@@ -689,11 +233,7 @@ as xs:int
 declare function matcher:count-unread-notifications()
 as xs:int
 {
-  xdmp:estimate(
-    cts:search(
-      fn:collection($const:NOTIFICATION-COLL),
-      cts:element-value-query(xs:QName("sm:status"), $STATUS-UNREAD))
-  )
+  not-impl:count-unread-notifications()
 };
 
 declare function matcher:update-notification-status(
@@ -701,8 +241,22 @@ declare function matcher:update-notification-status(
   $status as xs:string
 )
 {
-  xdmp:node-replace(
-    fn:doc($uri)/sm:notification/sm:meta/sm:status,
-    element sm:status { $status }
-  )
+  not-impl:update-notification-status($uri, $status)
 };
+
+declare function matcher:save-match-notification(
+  $threshold-label as xs:string,
+  $uris as xs:string*
+)
+{
+  not-impl:save-match-notification($threshold-label, $uris)
+};
+
+(:
+ : Delete the specified notification
+ :)
+declare function matcher:delete-notification($uri as xs:string)
+{
+  not-impl:delete-notification($uri)
+};
+

--- a/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher.xqy
+++ b/src/main/ml-modules/ext/com.marklogic.smart-mastering/matcher.xqy
@@ -6,7 +6,7 @@ import module namespace blocks-impl = "http://marklogic.com/smart-mastering/bloc
   at "/ext/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy";
 import module namespace match-impl = "http://marklogic.com/smart-mastering/matcher-impl"
   at "/ext/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy";
-import module namespace not-impl = "http://marklogic.com/smart-mastering/notification-impl"
+import module namespace notify-impl = "http://marklogic.com/smart-mastering/notification-impl"
   at "/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy";
 import module namespace opt-impl = "http://marklogic.com/smart-mastering/options-impl"
   at "/ext/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy";
@@ -206,7 +206,7 @@ declare function matcher:allow-match($uri1 as xs:string, $uri2 as xs:string)
 declare function matcher:get-notifications-as-xml($start as xs:int, $end as xs:int)
   as element(sm:notification)*
 {
-  not-impl:get-notifications-as-xml($start, $end)
+  notify-impl:get-notifications-as-xml($start, $end)
 };
 
 (:
@@ -215,7 +215,7 @@ declare function matcher:get-notifications-as-xml($start as xs:int, $end as xs:i
 declare function matcher:get-notifications-as-json($start as xs:int, $end as xs:int)
   as array-node()
 {
-  not-impl:get-notifications-as-json($start, $end)
+  notify-impl:get-notifications-as-json($start, $end)
 };
 
 (:
@@ -224,7 +224,7 @@ declare function matcher:get-notifications-as-json($start as xs:int, $end as xs:
 declare function matcher:count-notifications()
 as xs:int
 {
-  not-impl:count-notifications()
+  notify-impl:count-notifications()
 };
 
 (:
@@ -233,7 +233,7 @@ as xs:int
 declare function matcher:count-unread-notifications()
 as xs:int
 {
-  not-impl:count-unread-notifications()
+  notify-impl:count-unread-notifications()
 };
 
 declare function matcher:update-notification-status(
@@ -241,7 +241,7 @@ declare function matcher:update-notification-status(
   $status as xs:string
 )
 {
-  not-impl:update-notification-status($uri, $status)
+  notify-impl:update-notification-status($uri, $status)
 };
 
 declare function matcher:save-match-notification(
@@ -249,7 +249,7 @@ declare function matcher:save-match-notification(
   $uris as xs:string*
 )
 {
-  not-impl:save-match-notification($threshold-label, $uris)
+  notify-impl:save-match-notification($threshold-label, $uris)
 };
 
 (:
@@ -257,6 +257,6 @@ declare function matcher:save-match-notification(
  :)
 declare function matcher:delete-notification($uri as xs:string)
 {
-  not-impl:delete-notification($uri)
+  notify-impl:delete-notification($uri)
 };
 

--- a/src/main/ml-modules/services/sm-block-match.xqy
+++ b/src/main/ml-modules/services/sm-block-match.xqy
@@ -38,7 +38,7 @@ function post(
   let $uri2 := map:get($params, "uri2")
   return
     if (fn:exists($uri1) and fn:exists($uri2)) then
-      matcher:block-match($uri1, $uri2)
+      matcher:block-matches(($uri1, $uri2))
     else
       fn:error((),"RESTAPI-SRVEXERR",
         (400, "Bad Request",

--- a/src/main/ml-modules/services/sm-match-option-names.xqy
+++ b/src/main/ml-modules/services/sm-match-option-names.xqy
@@ -11,8 +11,6 @@ declare function get(
   ) as document-node()*
 {
   document {
-    let $option-names := matcher:get-option-names()
-    return
-      matcher:option-names-to-json($option-names)
+    matcher:get-option-names-as-json()
   }
 };

--- a/src/main/ml-modules/services/sm-match-options.xqy
+++ b/src/main/ml-modules/services/sm-match-options.xqy
@@ -13,9 +13,7 @@ declare function get(
   ) as document-node()*
 {
   document {
-    let $options := matcher:get-options(map:get($params, "name"))
-    return
-      matcher:options-to-json($options)
+    matcher:get-options-as-json(map:get($params, "name"))
   }
 };
 
@@ -36,14 +34,7 @@ function post(
   $input   as document-node()*
   ) as document-node()*
 {
-  let $options := $input/(matcher:options|object-node())
-  let $options :=
-    if ($options instance of object-node()) then
-      matcher:options-from-json($options)
-    else
-      $options
-  return
-    matcher:save-options(map:get($params, "name"), $options)
+  matcher:save-options(map:get($params, "name"), $input/(matcher:options|object-node()))
 };
 
 declare function delete(

--- a/src/main/ml-modules/services/sm-match.xqy
+++ b/src/main/ml-modules/services/sm-match.xqy
@@ -41,7 +41,7 @@ function post(
       fn:doc($uri)
   let $options :=
     if (map:contains($params, "options")) then
-      matcher:get-options(map:get($params, "options"))
+      matcher:get-options-as-xml(map:get($params, "options"))
     else
       $input-root/(*:options|.[object-node("options")])
   let $start :=

--- a/src/main/ml-modules/services/sm-notifications.xqy
+++ b/src/main/ml-modules/services/sm-notifications.xqy
@@ -15,19 +15,13 @@ declare function get(
   let $start := (map:get($params, "start"), 1)[1] ! xs:int(.)
   let $page-size := (map:get($params, "page-size"), 10)[1] ! xs:int(.)
   let $end := $start + $page-size - 1
-  let $notifications := matcher:get-notifications($start, $end)
   return
     document {
       object-node {
-      "total": matcher:count-notifications(),
-      "start": $start,
-      "page-size": $page-size,
-      "notifications":
-        array-node {
-          for $n in $notifications
-          return
-            matcher:notification-to-json($n)
-        }
+        "total": matcher:count-notifications(),
+        "start": $start,
+        "page-size": $page-size,
+        "notifications": matcher:get-notifications-as-json($start, $end)
       }
     }
 };

--- a/src/test/ml-modules/root/test/suites/matching/allow-match.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/allow-match.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
-at "/ext/com.marklogic.smart-mastering/matcher.xqy";
+  at "/ext/com.marklogic.smart-mastering/matcher.xqy";
 
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 

--- a/src/test/ml-modules/root/test/suites/matching/block-match.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/block-match.xqy
@@ -1,5 +1,7 @@
 xquery version "1.0-ml";
 
+import module namespace blocks-impl = "http://marklogic.com/smart-mastering/blocks-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/blocks-impl.xqy";
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/ext/com.marklogic.smart-mastering/matcher.xqy";
 
@@ -24,7 +26,7 @@ let $assertions := (
 (: Record a block :)
 let $_ :=
   xdmp:invoke-function(
-    function() { matcher:block-match($uri3, $uri4) },
+    function() { blocks-impl:block-match($uri3, $uri4) },
     <options xmlns="xdmp:eval">
       <isolation>different-transaction</isolation>
     </options>

--- a/src/test/ml-modules/root/test/suites/matching/options-to-json.sjs
+++ b/src/test/ml-modules/root/test/suites/matching/options-to-json.sjs
@@ -3,8 +3,6 @@ const matcher = require('/ext/com.marklogic.smart-mastering/matcher.xqy');
 
 const actual = matcher.getOptionsAsJson("match-test");
 
-// const actual = matcher.optionsToJson(options).root;
-
 [].concat(
   test.assertEqual("200", actual.options.tuning['max-scan'].data),
   test.assertEqual(7, actual.options['property-defs'].property.length),

--- a/src/test/ml-modules/root/test/suites/matching/options-to-json.sjs
+++ b/src/test/ml-modules/root/test/suites/matching/options-to-json.sjs
@@ -1,9 +1,9 @@
 const test = require('/test/test-helper.xqy');
 const matcher = require('/ext/com.marklogic.smart-mastering/matcher.xqy');
 
-const options = matcher.getOptions("match-test");
+const actual = matcher.getOptionsAsJson("match-test");
 
-const actual = matcher.optionsToJson(options).root;
+// const actual = matcher.optionsToJson(options).root;
 
 [].concat(
   test.assertEqual("200", actual.options.tuning['max-scan'].data),

--- a/src/test/ml-modules/root/test/suites/matching/setup.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/setup.xqy
@@ -1,9 +1,9 @@
 xquery version "1.0-ml";
 
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/ext/com.marklogic.smart-mastering/constants.xqy";
 import module namespace sem = "http://marklogic.com/semantics"
   at "/MarkLogic/semantics.xqy";
-import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
-  at "/ext/com.marklogic.smart-mastering/matcher.xqy";
 
 declare option xdmp:mapping "false";
 
@@ -13,7 +13,7 @@ let $uri2 := "/content2.xml"
 return
   sem:rdf-insert(
   (
-    sem:triple(sem:iri($uri1), $matcher:PRED-MATCH-BLOCK, sem:iri($uri2)),
-    sem:triple(sem:iri($uri2), $matcher:PRED-MATCH-BLOCK, sem:iri($uri1))
+    sem:triple(sem:iri($uri1), $const:PRED-MATCH-BLOCK, sem:iri($uri2)),
+    sem:triple(sem:iri($uri2), $const:PRED-MATCH-BLOCK, sem:iri($uri1))
   )
 )

--- a/src/test/ml-modules/root/test/suites/notifications/get-notifications.xqy
+++ b/src/test/ml-modules/root/test/suites/notifications/get-notifications.xqy
@@ -11,7 +11,7 @@ declare namespace sm = "http://marklogic.com/smart-mastering";
 
 declare option xdmp:mapping "false";
 
-let $actual := matcher:get-notifications(1, 10)
+let $actual := matcher:get-notifications-as-xml(1, 10)
 let $likely := $actual[sm:threshold-label = $lib:LBL-LIKELY]
 let $possible := $actual[sm:threshold-label = $lib:LBL-POSSIBLE]
 

--- a/src/test/ml-modules/root/test/suites/notifications/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/notifications/lib/lib.xqy
@@ -4,7 +4,7 @@ module namespace lib = "http://marklogic.com/smart-mastering/test/notification";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/ext/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace not-impl = "http://marklogic.com/smart-mastering/notification-impl"
+import module namespace notify-impl = "http://marklogic.com/smart-mastering/notification-impl"
   at "/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy";
 
 declare variable $INVOKE_OPTIONS :=
@@ -21,7 +21,7 @@ declare variable $URI-SET2 := ("/content4.xml", "/content5.xml");
 (: Get a notification without creating a lock. :)
 declare function lib:get-notification($label, $uris)
 {
-  xdmp:invoke-function(function() { not-impl:get-existing-match-notification($label, $uris) }, $INVOKE_OPTIONS)
+  xdmp:invoke-function(function() { notify-impl:get-existing-match-notification($label, $uris) }, $INVOKE_OPTIONS)
 };
 
 (: Call the save-match-nofication function in a different transaction :)

--- a/src/test/ml-modules/root/test/suites/notifications/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/notifications/lib/lib.xqy
@@ -3,7 +3,9 @@ xquery version "1.0-ml";
 module namespace lib = "http://marklogic.com/smart-mastering/test/notification";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
-at "/ext/com.marklogic.smart-mastering/matcher.xqy";
+  at "/ext/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace not-impl = "http://marklogic.com/smart-mastering/notification-impl"
+  at "/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy";
 
 declare variable $INVOKE_OPTIONS :=
   <options xmlns="xdmp:eval">
@@ -19,7 +21,7 @@ declare variable $URI-SET2 := ("/content4.xml", "/content5.xml");
 (: Get a notification without creating a lock. :)
 declare function lib:get-notification($label, $uris)
 {
-  xdmp:invoke-function(function() { matcher:get-existing-match-notification($label, $uris) }, $INVOKE_OPTIONS)
+  xdmp:invoke-function(function() { not-impl:get-existing-match-notification($label, $uris) }, $INVOKE_OPTIONS)
 };
 
 (: Call the save-match-nofication function in a different transaction :)

--- a/src/test/ml-modules/root/test/suites/notifications/notifications-to-json.sjs
+++ b/src/test/ml-modules/root/test/suites/notifications/notifications-to-json.sjs
@@ -1,11 +1,13 @@
 const test = require('/test/test-helper.xqy');
+const con = require('/ext/com.marklogic.smart-mastering/constants.xqy');
 const matcher = require('/ext/com.marklogic.smart-mastering/matcher.xqy');
+const notify = require('/ext/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy');
 const lib = require('/test/suites/notifications/lib/lib.xqy');
 
 
-const notificationXML = matcher.getExistingMatchNotification(lib['LBL-LIKELY'], lib['URI-SET1']);
+const notificationXML = notify.getExistingMatchNotification(lib['LBL-LIKELY'], lib['URI-SET1']);
 const notificationURI = fn.baseUri(notificationXML);
-const notification = matcher.notificationToJson(notificationXML);
+const notification = notify.notificationToJson(notificationXML);
 
 const notifyObj = notification.toObject();
 
@@ -13,5 +15,5 @@ const notifyObj = notification.toObject();
   test.assertEqual(lib['LBL-LIKELY'], notifyObj.thresholdLabel),
   test.assertEqual(fn.count(lib['URI-SET1']), notifyObj.uris.length),
   test.assertEqual(notificationURI, notifyObj.meta.uri),
-  test.assertEqual(matcher['STATUS-UNREAD'], notifyObj.meta.status)
+  test.assertEqual(con['STATUS-UNREAD'], notifyObj.meta.status)
 )

--- a/src/test/ml-modules/root/test/suites/notifications/update-notifications.xqy
+++ b/src/test/ml-modules/root/test/suites/notifications/update-notifications.xqy
@@ -1,7 +1,9 @@
 xquery version "1.0-ml";
 
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/ext/com.marklogic.smart-mastering/constants.xqy";
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
-at "/ext/com.marklogic.smart-mastering/matcher.xqy";
+  at "/ext/com.marklogic.smart-mastering/matcher.xqy";
 
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 
@@ -19,7 +21,7 @@ let $notification := lib:get-notification($lib:LBL-LIKELY, $lib:URI-SET1)
 (: Verify starting state :)
 let $assertions := (
   test:assert-equal(
-    element sm:status { $matcher:STATUS-UNREAD },
+    element sm:status { $const:STATUS-UNREAD },
     $notification/sm:meta/sm:status
   )
 )
@@ -27,7 +29,7 @@ let $assertions := (
 let $_ :=
   xdmp:invoke-function(
     function() {
-      matcher:update-notification-status(fn:base-uri($notification), $matcher:STATUS-READ)
+      matcher:update-notification-status(fn:base-uri($notification), $const:STATUS-READ)
     },
     $lib:INVOKE_OPTIONS
   )
@@ -37,7 +39,7 @@ let $notification := lib:get-notification($lib:LBL-LIKELY, $lib:URI-SET1)
 let $assertions := (
   $assertions,
   test:assert-equal(
-    element sm:status { $matcher:STATUS-READ },
+    element sm:status { $const:STATUS-READ },
     $notification/sm:meta/sm:status
   )
 )


### PR DESCRIPTION
- separated public API functions in matcher.xqy from implementation functions
- probably makes sense to start the review with the much-reduced matcher.xqy
- split the implementation functions into multiple files based on functionality
- added a bunch of parameter and return types
- Question: I set up some functions to have `-as-xml` and `-as-json` variants. Does that look good, or would it be better to have a `$format` parameter? 
- all unit tests pass
- no syntax errors from the services