### PR TITLE
Ignoring dhf-flow gradle-local.properties

### DIFF
--- a/examples/dhf-flow/.gitignore
+++ b/examples/dhf-flow/.gitignore
@@ -2,4 +2,3 @@ build/
 .tmp/
 .gradle/
 .DS_Store
-!gradle-local.properties

--- a/examples/dhf-flow/README.md
+++ b/examples/dhf-flow/README.md
@@ -4,7 +4,7 @@ This example shows you how to integrate Smart Mastering with your Data Hub Flows
 
 ## Setup
 
-- Add your username and password to **gradle-local.properties**
+- Create the file **gradle-local.properties** in the same directory as this README file and add your MarkLogic admin username and password to it:
   ```
   mlUsername=admin
   mlPassword=admin

--- a/examples/dhf-flow/gradle-local.properties
+++ b/examples/dhf-flow/gradle-local.properties
@@ -1,4 +1,0 @@
-# Put your overrides from gradle.properties here
-
-mlUsername=
-mlPassword=


### PR DESCRIPTION
Feel free to reject this. I'm proposing this because I cloned smart-mastering-core, and then I tried out dhf-flow, which required modifying gradle-local.properties. But since that's not a gitignore'd file, my modification of course showed up when I went to create a PR for a different purpose. 

I think that if someone is able to clone smart-mastering-core and try out dhf-flow locally, they should be fine creating gradle-local.properties themselves and modifying mlUsername/mlPassword in it, which the README makes clear. 