### PR TITLE
Mdm 348

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.iml
 gradle-local.properties
 .gradletasknamecache
+docs

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -401,7 +401,6 @@ declare function merge-impl:build-headers(
         let $populate := merge-impl:combine("", $anc-path-map, $configured-paths, ($docs/es:envelope/es:headers/*[fn:empty(self::sm:*)]), $m)
         let $add-merged-values := merge-impl:add-merged-values($final-headers, $m)
         return $m
-      let $_ := xdmp:log("combined: " || xdmp:quote($combined))
       return merge-impl:map-to-xml($combined, $headers-ns-map)
     }
   </es:headers>
@@ -493,7 +492,6 @@ declare function merge-impl:map-to-xml($m as map:map, $ns-map as map:map)
 {
   for $path in map:keys($m)
   let $value := map:get($m, $path)
-  let $_ := xdmp:log("map value: " || xdmp:quote($value))
   return
     if ($value instance of map:map) then
       if (map:contains($value, "sources") and map:contains($value, "values") and map:contains($value, "name")) then
@@ -503,19 +501,10 @@ declare function merge-impl:map-to-xml($m as map:map, $ns-map as map:map)
           merge-impl:map-to-xml($value, $ns-map)
         }
     else if ($value instance of object-node()+) then (
-      xdmp:log("case: object"),
-      let $node := $value/values
-      let $_ := xdmp:log("node: " || xdmp:quote($node))
-      return (
-        (: We already have the element itself, just need to get its contents :)
-        $node/@*,
-        $node/node()
-      )
+      $value/values
     )
-    else (
-      xdmp:log("case: else"),
+    else
       $value
-    )
 };
 
 declare function merge-impl:build-merge-models-by-final-properties-to-json(
@@ -775,7 +764,7 @@ declare function merge-impl:get-raw-values(
   $docs,
   $property as element(merging:property),
   $sources,
-  $ns-map as map:map
+  $ns-map as map:map?
 ) as map:map*
 {
   let $wrapped := map:map()
@@ -810,7 +799,7 @@ declare function merge-impl:build-final-properties(
 ) as map:map*
 {
   let $top-level-properties := fn:distinct-values($instances/* ! fn:node-name(.))
-  let $property-defs := $merge-options/merging:property-defs[fn:exists(@localname)]
+  let $property-defs := $merge-options/merging:property-defs[fn:exists(merging:property/@localname)]
   let $algorithms-map := merge-impl:build-merging-map($merge-options)
   let $merge-options-uri := $merge-options ! xdmp:node-uri(.)
   let $merge-options-ref :=

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -724,7 +724,12 @@ declare function merge-impl:get-sources($docs)
 declare variable $PROPKEY-HEADERS-NS-MAP := "headers-ns-map";
 
 (:~
- : TODO
+ : Extract the instance parts from the source documents and pass them to
+ : functions that will do the property and header merges. Return a map with
+ : that data.
+ : @param $uris  URIs of the source documents
+ : @param $merge-options  these control how the source data get merged together
+ : @return map:map with merged information from the source docs
  :)
 declare function merge-impl:parse-final-properties-for-merge(
   $uris as xs:string*,
@@ -776,16 +781,18 @@ declare function merge-impl:parse-final-properties-for-merge(
 };
 
 (:~
- : TODO
- : @param $merge-options an element or object containing the merge options
- : @param $docs the source documents the header values will be drawn from
- : @param $sources TODO
+ : Build a sequence of maps that contain, for each configured header, the
+ : algorithm used to do the merging, the merged values, and the sources of
+ : those values (embedded in the values).
+ : @param $merge-options  an element or object containing the merge options
+ : @param $docs  the source documents the header values will be drawn from
+ : @param $sources  information about the source of the header data
  : @return sequence of maps. First map is the mapping from namespace prefixes
  :         to namespace URIs, as configured on the property-defs element. The
  :         rest of the maps are final header values.
  :)
 declare function merge-impl:build-final-headers(
-  $merge-options,
+  $merge-options as element(merging:options),
   $docs,
   $sources
 ) as map:map*
@@ -824,7 +831,6 @@ declare function merge-impl:build-final-headers(
       if (fn:exists($raw-values)) then
         map:new((
           map:entry("algorithm", $algorithm-info),
-          map:entry("sources", 1),
           map:entry("values",
             (: get the merged values :)
             if (fn:exists($algorithm)) then
@@ -849,11 +855,13 @@ declare function merge-impl:build-final-headers(
 
 (:~
  : Identify and merge any headers whose paths are given in the merge options.
- : @param $docs TODO
- : @param $property TODO
- : @param $sources TODO
+ : @param $docs  the source documents
+ : @param $property  the property specification, which includes the path to
+ :                   look for source values
+ : @param $sources  structure reflecting the origin of the data
  : @param $ns-map maps from namespace prefixes to namespace URIs
- : @return TODO
+ : @return a sequence of maps, one for each value of this property found in a
+ :         source document
  :)
 declare function merge-impl:get-raw-values(
   $docs,

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -339,20 +339,9 @@ declare function merge-impl:build-merge-models-by-final-properties-to-xml(
   let $uris := $docs ! xdmp:node-uri(.)
   return
     <es:envelope>
-      <es:headers>
-        <sm:id>{$id}</sm:id>
-        <sm:merges>{
-          $docs/es:envelope/es:headers/sm:merges/sm:document-uri,
-          $uris ! element sm:document-uri { . }
-        }</sm:merges>
-        <sm:sources>{
-          $docs/es:envelope/es:headers/sm:sources/sm:source
-        }</sm:sources>
-        {
-          (: TODO Add logic for merging headers :)
-          $docs/es:envelope/es:headers/*[fn:empty(self::sm:*)]
-        }
-      </es:headers>
+      {
+        merge-impl:build-headers($id, $docs, $uris, $final-properties)
+      }
       <es:triples>{
         sem:sparql(
           'construct { ?s ?p ?o } where { ?s ?p ?o }',
@@ -368,6 +357,29 @@ declare function merge-impl:build-merge-models-by-final-properties-to-xml(
         )
       }</es:instance>
     </es:envelope>
+};
+
+declare function merge-impl:build-headers(
+  $id as xs:string,
+  $docs as node()*,
+  $uris as xs:string*,
+  $final-properties as item()*
+) as element(es:headers)
+{
+  <es:headers>
+    <sm:id>{$id}</sm:id>
+    <sm:merges>{
+      $docs/es:envelope/es:headers/sm:merges/sm:document-uri,
+      $uris ! element sm:document-uri { . }
+    }</sm:merges>
+    <sm:sources>{
+      $docs/es:envelope/es:headers/sm:sources/sm:source
+    }</sm:sources>
+    {
+      (: TODO Add logic for merging headers :)
+      $docs/es:envelope/es:headers/*[fn:empty(self::sm:*)]
+    }
+  </es:headers>
 };
 
 declare function merge-impl:build-merge-models-by-final-properties-to-json(

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -685,12 +685,15 @@ declare function merge-impl:parse-final-properties-for-merge(
 
 (:~
  : TODO
+ : @param $merge-options an element or object containing the merge options
+ : @param $docs the source documents the header values will be drawn from
+ : @param $sources TODO
  : @return sequence of maps. First map is the mapping from namespace prefixes
  :         to namespace URIs, as configured on the property-defs element. The
  :         rest of the maps are final header values.
  :)
 declare function merge-impl:build-final-headers(
-  $merge-options as element(merging:options),
+  $merge-options,
   $docs,
   $sources
 ) as map:map*
@@ -1100,8 +1103,8 @@ declare function merge-impl:_options-json-config()
   let $config := json:config("custom")
   return (
     map:put($config, "array-element-names", ("algorithm","threshold","scoring","property", "reduce", "add", "expand")),
-    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/matcher"),
-    map:put($config, "element-namespace-prefix", "matcher"),
+    map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/merging"),
+    map:put($config, "element-namespace-prefix", "merging"),
     map:put($config, "attribute-names",
       ("name","localname", "namespace", "function",
         "at", "property-name", "weight", "above", "label","algorithm-ref")

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
@@ -50,7 +50,6 @@ declare function merging:standard(
               /m:source-weights
               /m:source[@name = $source/name]/@weight
         ))
-      let $_ := xdmp:log("source score=" || $source-score)
       let $weight := $length-score + $source-score
       stable order by $weight descending, $source-dateTime descending
       return

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
@@ -2,10 +2,11 @@ xquery version "1.0-ml";
 
 module namespace merging = "http://marklogic.com/smart-mastering/survivorship/merging";
 
+declare namespace m = "http://marklogic.com/smart-mastering/merging";
 (:
  : This is the default method of combining the set of values for a property across entities that are being merged.
  : Sample $property-spec:
- :     <merge property-name="name"  max-values="1">
+ :     <merge property-name="name" max-values="1" xmlns="http://marklogic.com/smart-mastering/merging">
  :       <length weight="8" />
  :       <source-weights>
  :         <source name="good-source" weight="2"/>
@@ -16,7 +17,7 @@ module namespace merging = "http://marklogic.com/smart-mastering/survivorship/me
  : @param $property-name  The name of the property being merged
  : @param $all-properties  A sequence of maps, each with "name" (the name of the property), "sources" (the URIs of the
  :                         lineage docs the value came from), and "values" (a value for that property).
- : @param $property-spec  The /merging:merging/merging:merge element of merge options that corresponds to a particular property
+ : @param $property-spec  The /m:merging/m:merge element of merge options that corresponds to a particular property
  :
  : @return selected property value(s)
  :)
@@ -30,7 +31,7 @@ declare function merging:standard(
     (
       let $length-weight :=
         fn:head((
-          $property-spec/merging:length/@weight ! fn:number(.),
+          $property-spec/m:length/@weight ! fn:number(.),
           0
         ))
       for $property in merging:standard-condense-properties(
@@ -46,9 +47,10 @@ declare function merging:standard(
           for $source in $sources
           return
             $property-spec
-              /merging:source-weights
-              /merging:source[@name = $source/name]/@weight
+              /m:source-weights
+              /m:source[@name = $source/name]/@weight
         ))
+      let $_ := xdmp:log("source score=" || $source-score)
       let $weight := $length-score + $source-score
       stable order by $weight descending, $source-dateTime descending
       return

--- a/src/test/ml-modules/root/test/suites/merging-json/test-data/merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-json/test-data/merge-options.xml
@@ -7,7 +7,6 @@
   </property-defs>
   <algorithms>
     <algorithm name="name" function="name"/>
-    <algorithm name="address" function="address"/>
   </algorithms>
   <merging>
     <merge property-name="ssn" algorithm-ref="user-defined">
@@ -21,12 +20,10 @@
       <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
       <length weight="8" />
     </merge>
-    <merge property-name="address" algorithm-ref="address" max-values="1">
-      <postal-code prefer="zip+4" />
-      <length weight="8" />
-      <double-metaphone>
-        <distance-threshold>50</distance-threshold>
-      </double-metaphone>
+    <merge property-name="address" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE2" weight="10"></source>
+      </source-weights>
     </merge>
   </merging>
 </options>

--- a/src/test/ml-modules/root/test/suites/merging-xml-non-person/test-data/merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml-non-person/test-data/merge-options.xml
@@ -7,7 +7,6 @@
   </property-defs>
   <algorithms>
     <algorithm name="name" function="name"/>
-    <algorithm name="address" function="address"/>
   </algorithms>
   <merging>
     <merge property-name="ssn" algorithm-ref="user-defined">
@@ -21,12 +20,10 @@
       <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
       <length weight="8" />
     </merge>
-    <merge property-name="address" algorithm-ref="address" max-values="1">
-      <postal-code prefer="zip+4" />
-      <length weight="8" />
-      <double-metaphone>
-        <distance-threshold>50</distance-threshold>
-      </double-metaphone>
+    <merge property-name="address" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE2" weight="10"></source>
+      </source-weights>
     </merge>
   </merging>
 </options>

--- a/src/test/ml-modules/root/test/suites/merging-xml/custom-sjs-action.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/custom-sjs-action.xqy
@@ -53,10 +53,22 @@ let $assertions := (
         "options": object-node{
           "matchOptions": "custom-sjs-action-match-options",
           "propertyDefs": object-node {
-            "property": object-node {
+            "property": array-node {
+              object-node {
               "namespace": "",
-              "localname": "Address",
-              "name": "address"
+              "localname": "IdentificationID",
+              "name": "ssn"
+              },
+              object-node {
+                "namespace": "",
+                "localname": "PersonName",
+                "name": "name"
+              },
+              object-node {
+                "namespace": "",
+                "localname": "Address",
+                "name": "address"
+              }
             }
           },
           "merging": object-node {

--- a/src/test/ml-modules/root/test/suites/merging-xml/get-raw-values.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/get-raw-values.xqy
@@ -33,7 +33,8 @@ let $actual :=
   merge-impl:get-raw-values(
     $docs,
     $shallow-prop,
-    $sources
+    $sources,
+    ()
   )
 (:
  : Expecting all values from sources:
@@ -76,7 +77,11 @@ let $actual :=
   merge-impl:get-raw-values(
     $docs,
     $deep-prop,
-    $sources
+    $sources,
+    map:new((
+      map:entry("es", "http://marklogic.com/entity-services"),
+      map:entry("has", "has")
+    ))
   )
 
 (:
@@ -85,7 +90,7 @@ let $actual :=
       "sources":[{"name":"SOURCE1", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/1/doc1.xml"},{"name":"SOURCE2", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/2/doc2.xml"}],
       "values":"<path xmlns=\"\">deep value 1</path><path xmlns=\"\">deep value 2</path>",
       "namespaces": [{"es": "http://marklogic.com/entity-services"}],
-      "path":"/es:envelope/es:headers/custom/this/has/a/deep/path",
+      "path":"/es:envelope/es:headers/custom/this/has:a/deep/path",
       "propQName": "path"
     }
  :)

--- a/src/test/ml-modules/root/test/suites/merging-xml/get-raw-values.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/get-raw-values.xqy
@@ -1,0 +1,114 @@
+xquery version "1.0-ml";
+
+(:
+ : Test the custom xqy algorithm feature.
+ :)
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
+  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+import module namespace merging = "http://marklogic.com/smart-mastering/merging"
+  at "/com.marklogic.smart-mastering/merging.xqy";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+declare namespace es = "http://marklogic.com/entity-services";
+declare namespace sm = "http://marklogic.com/smart-mastering";
+
+declare option xdmp:mapping "false";
+
+let $options := merge-impl:get-options($lib:OPTIONS-NAME-PATH, $const:FORMAT-XML)
+
+let $shallow-prop := $options/merging:property-defs/merging:property[@name="shallow"]
+
+let $deep-prop := $options/merging:property-defs/merging:property[@name="deep"]
+
+let $docs := map:keys($lib:TEST-DATA) ! fn:doc(.)
+
+let $sources := merge-impl:get-sources($docs)
+
+let $actual :=
+  merge-impl:get-raw-values(
+    $docs,
+    $shallow-prop,
+    $sources
+  )
+(:
+ : Expecting all values from sources:
+
+    {
+      "sources":{"name":"SOURCE1", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/1/doc1.xml"},
+      "values":"<shallow xmlns=\"\">shallow value 1</shallow>",
+      "name": "shallow"
+    }
+    {
+      "sources":{"name":"SOURCE2", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/2/doc2.xml"},
+      "values":"<shallow xmlns=\"\">shallow value 2</shallow>",
+      "name": "shallow"
+    }
+ :)
+let $assertions := (
+  test:assert-equal(2, fn:count($actual)),
+
+  for $act in $actual
+  let $src-name := map:get($act, "sources")/name/fn:string()
+  return
+    if ($src-name = "SOURCE1") then
+      test:assert-equal-xml(
+        <shallow xmlns="">shallow value 1</shallow>,
+        map:get($act, "values")
+      )
+    else if ($src-name = "SOURCE2") then
+      test:assert-equal-xml(
+        <shallow xmlns="">shallow value 2</shallow>,
+        map:get($act, "values")
+      )
+    else
+      test:fail("invalid source: " || $src-name),
+
+  test:assert-equal(xs:QName("shallow"), map:get($actual[1], "name")),
+  test:assert-equal(xs:QName("shallow"), map:get($actual[2], "name"))
+)
+
+let $actual :=
+  merge-impl:get-raw-values(
+    $docs,
+    $deep-prop,
+    $sources
+  )
+
+(:
+ : Expecting all values from sources:
+    {
+      "sources":[{"name":"SOURCE1", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/1/doc1.xml"},{"name":"SOURCE2", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/2/doc2.xml"}],
+      "values":"<path xmlns=\"\">deep value 1</path><path xmlns=\"\">deep value 2</path>",
+      "namespaces": [{"es": "http://marklogic.com/entity-services"}],
+      "path":"/es:envelope/es:headers/custom/this/has/a/deep/path",
+      "propQName": "path"
+    }
+ :)
+return (
+  $assertions,
+  test:assert-equal(2, fn:count($actual)),
+
+  for $act in $actual
+  let $src-name := map:get($act, "sources")/name/fn:string()
+  return
+    if ($src-name = "SOURCE1") then
+      test:assert-equal-xml(
+        <path xmlns="">deep value 1</path>,
+        map:get($act, "values")
+      )
+    else if ($src-name = "SOURCE2") then
+      test:assert-equal-xml(
+        <path xmlns="">deep value 2</path>,
+        map:get($act, "values")
+      )
+    else
+      test:fail("invalid source: " || $src-name),
+
+  test:assert-equal(xs:QName("path"), map:get($actual[1], "name")),
+  test:assert-equal(xs:QName("path"), map:get($actual[2], "name"))
+)

--- a/src/test/ml-modules/root/test/suites/merging-xml/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/lib/lib.xqy
@@ -17,9 +17,9 @@ declare variable $OPTIONS-NAME := "test-options";
 
 declare variable $OPTIONS-NAME-CUST-XQY := "cust-xqy-test-options";
 declare variable $OPTIONS-NAME-CUST-SJS := "cust-sjs-test-options";
+declare variable $OPTIONS-NAME-PATH := "path-test-options";
 
 declare variable $OPTIONS-NAME-CUST-ACTION-XQY-MATCH := "custom-xqy-action-match-options";
 declare variable $OPTIONS-NAME-CUST-ACTION-XQY-MERGE := "custom-xqy-action-merge-options";
 declare variable $OPTIONS-NAME-CUST-ACTION-SJS-MATCH := "custom-sjs-action-match-options";
 declare variable $OPTIONS-NAME-CUST-ACTION-SJS-MERGE := "custom-sjs-action-merge-options";
-

--- a/src/test/ml-modules/root/test/suites/merging-xml/map-to-xml.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/map-to-xml.xqy
@@ -1,0 +1,107 @@
+xquery version "1.0-ml";
+
+(:
+ : Test the custom xqy algorithm feature.
+ :)
+
+import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
+  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare namespace es = "http://marklogic.com/entity-services";
+declare namespace sm = "http://marklogic.com/smart-mastering";
+declare namespace has = "has";
+
+declare option xdmp:mapping "false";
+
+let $m :=
+  map:new((
+    map:entry(
+      "custom",
+      map:new((
+        map:entry(
+          "unconfigured",
+          (
+            <unconfigured xmlns="" xmlns:has="has">unconfigured value 2b</unconfigured>,
+            <unconfigured xmlns="" xmlns:has="has">unconfigured value 1b</unconfigured>
+          )
+        ),
+        map:entry(
+          "this",
+          map:new((
+            map:entry(
+              "has:a",
+              map:new((
+                map:entry(
+                  "deep",
+                  map:new((
+                    map:entry(
+                      "path",
+                      map:new((
+                        map:entry(
+                          "sources",
+                          (
+                            object-node{"name":"SOURCE2", "dateTime":"2018-04-26T16:40:16.760311Z", "documentUri":"/source/2/doc2.xml"},
+                            object-node{"name":"SOURCE1", "dateTime":"2018-04-26T16:40:02.1386Z", "documentUri":"/source/1/doc1.xml"}
+                          )
+                        ),
+                        map:entry("values", <path xmlns="" xmlns:has="has">deep value 21</path>)
+                      ))
+                    )
+                  ))
+                )
+              ))
+            )
+          ))
+        )
+      ))
+    ),
+    map:entry(
+      "shallow",
+      map:new((
+        map:entry(
+          "sources",
+          object-node { "name":"SOURCE1", "dateTime":"2018-04-26T16:40:02.1386Z", "documentUri":"/source/1/doc1.xml" }
+        ),
+        map:entry("values", <shallow xmlns="">shallow value 1</shallow>),
+        map:entry("name", "shallow")
+      ))
+    ),
+    map:entry(
+      "{http://marklogic.com/entity-services}unconfigured",
+      (
+        <unconfigured xmlns="http://marklogic.com/entity-services">unconfigured value 2a</unconfigured>,
+        <unconfigured xmlns="http://marklogic.com/entity-services">unconfigured value 1a</unconfigured>
+      )
+    )
+  ))
+let $ns-map :=
+  map:new((
+    map:entry("has", "has")
+  ))
+let $actual := merge-impl:map-to-xml($m, $ns-map)
+(:
+ : Expecting:
+ (
+    <unconfigured xmlns="http://marklogic.com/entity-services">unconfigured value 2a</unconfigured>,
+    <unconfigured xmlns="http://marklogic.com/entity-services">unconfigured value 1a</unconfigured>,
+    <shallow>shallow value 1</shallow>,
+    <custom>
+      <unconfigured xmlns:has="has">unconfigured value 2b</unconfigured>
+      <unconfigured xmlns:has="has">unconfigured value 1b</unconfigured>
+      <this><has:a xmlns:has="has"><deep><path><path>deep value 21</path></path></deep></has:a></this>
+    </custom>
+ )
+ :)
+let $unconfigured := $actual[fn:node-name(.) eq xs:QName("es:unconfigured")]
+let $shallow := $actual[fn:node-name(.) eq xs:QName("shallow")]
+return (
+  test:assert-equal(2, fn:count($unconfigured)),
+  test:assert-same-values(
+    ("unconfigured value 1a", "unconfigured value 2a"),
+    $unconfigured/fn:string()
+  ),
+  test:assert-equal(1, fn:count($shallow)),
+  test:assert-equal(text { "shallow value 1" }, $shallow/text())
+)

--- a/src/test/ml-modules/root/test/suites/merging-xml/map-to-xml.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/map-to-xml.xqy
@@ -80,7 +80,7 @@ let $ns-map :=
   map:new((
     map:entry("has", "has")
   ))
-let $actual := merge-impl:map-to-xml($m, $ns-map)
+let $actual := merge-impl:map-to-xml($ns-map, $m)
 (:
  : Expecting:
  (

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
@@ -16,6 +16,7 @@ import module namespace lib = "http://marklogic.com/smart-mastering/test" at "li
 
 declare namespace es = "http://marklogic.com/entity-services";
 declare namespace sm = "http://marklogic.com/smart-mastering";
+declare namespace has = "has";
 
 (: Force update mode :)
 declare option xdmp:update "true";
@@ -50,7 +51,7 @@ let $merged-doc :=
 
 return (
   test:assert-equal("shallow value 1", $merged-doc/es:headers/shallow/fn:string()),
-  test:assert-equal("deep value 12", $merged-doc/es:headers/custom/this/has/a/deep/path/fn:string()),
+  test:assert-equal("deep value 12", $merged-doc/es:headers/custom/this/has:a/deep/path/fn:string()),
   test:assert-same-values(("unconfigured value 1a", "unconfigured value 2a"), $merged-doc/es:headers/es:unconfigured/fn:string()),
   test:assert-same-values(("unconfigured value 1b", "unconfigured value 2b"), $merged-doc/es:headers/custom/unconfigured/fn:string())
 )

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
@@ -49,8 +49,8 @@ let $merged-doc :=
  :)
 
 return (
-  test:assert-equal("shallow value 1", $merged-doc/headers/shallow/fn:string()),
-  test:assert-equal("deep value 12", $merged-doc/headers/custom/this/has/a/deep/path/fn:string()),
-  test:assert-same-values(("unconfigured value 1a", "unconfigured value 2a"), $merged-doc/headers/unconfigured/fn:string()),
-  test:assert-same-values(("unconfigured value 1b", "unconfigured value 1b"), $merged-doc/headers/custom/unconfigured/fn:string())
+  test:assert-equal("shallow value 1", $merged-doc/es:headers/shallow/fn:string()),
+  test:assert-equal("deep value 12", $merged-doc/es:headers/custom/this/has/a/deep/path/fn:string()),
+  test:assert-same-values(("unconfigured value 1a", "unconfigured value 2a"), $merged-doc/es:headers/es:unconfigured/fn:string()),
+  test:assert-same-values(("unconfigured value 1b", "unconfigured value 2b"), $merged-doc/es:headers/custom/unconfigured/fn:string())
 )

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
@@ -33,6 +33,7 @@ let $merged-doc :=
     },
     $lib:INVOKE_OPTIONS
   )
+let $_ := xdmp:log("merged doc: " || xdmp:quote($merged-doc/es:headers))
 (:
  : Expecting this for <headers>:
 

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-by-path.xqy
@@ -1,0 +1,56 @@
+xquery version "1.0-ml";
+
+(:
+ : Test the custom xqy algorithm feature.
+ :)
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace merging = "http://marklogic.com/smart-mastering/merging"
+  at "/com.marklogic.smart-mastering/merging.xqy";
+import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
+  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+declare namespace es = "http://marklogic.com/entity-services";
+declare namespace sm = "http://marklogic.com/smart-mastering";
+
+(: Force update mode :)
+declare option xdmp:update "true";
+
+declare option xdmp:mapping "false";
+
+(: Merge a couple documents :)
+let $merged-doc :=
+  xdmp:invoke-function(
+    function() {
+      merging:save-merge-models-by-uri(
+        map:keys($lib:TEST-DATA),
+        merging:get-options($lib:OPTIONS-NAME-PATH, $const:FORMAT-XML))
+    },
+    $lib:INVOKE_OPTIONS
+  )
+(:
+ : Expecting this for <headers>:
+
+<headers>
+  <!-- regular SM, ES headers, plus: -->
+  <unconfigured xmlns="http://marklogic.com/entity-services">unconfigured value 2a</unconfigured>
+  <unconfigured xmlns="http://marklogic.com/entity-services">unconfigured value 1a</unconfigured>
+  <shallow>shallow value 1</shallow>
+  <custom>
+    <unconfigured>unconfigured value 1b</unconfigured>
+    <unconfigured>unconfigured value 2b</unconfigured>
+    <this><has><a><deep><path>deep value 12</path></deep></a></has></this>
+  </custom>
+</headers>
+ :)
+
+return (
+  test:assert-equal("shallow value 1", $merged-doc/headers/shallow/fn:string()),
+  test:assert-equal("deep value 12", $merged-doc/headers/custom/this/has/a/deep/path/fn:string()),
+  test:assert-same-values(("unconfigured value 1a", "unconfigured value 2a"), $merged-doc/headers/unconfigured/fn:string()),
+  test:assert-same-values(("unconfigured value 1b", "unconfigured value 1b"), $merged-doc/headers/custom/unconfigured/fn:string())
+)

--- a/src/test/ml-modules/root/test/suites/merging-xml/rollback-merge.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/rollback-merge.xqy
@@ -39,7 +39,28 @@ let $assertions := xdmp:eager(
   let $smid := $merged-doc/es:headers/sm:id/fn:string()
   let $s1-dt := $merged-doc//sm:source[sm:name = "SOURCE1"]/sm:dateTime/fn:string()
   let $s2-dt := $merged-doc//sm:source[sm:name = "SOURCE2"]/sm:dateTime/fn:string()
-  let $expected-headers := <es:headers><sm:id xmlns:sm="http://marklogic.com/smart-mastering">{$smid}</sm:id><sm:merges xmlns:sm="http://marklogic.com/smart-mastering"><sm:document-uri>/source/2/doc2.xml</sm:document-uri><sm:document-uri>/source/1/doc1.xml</sm:document-uri></sm:merges><sm:sources xmlns:sm="http://marklogic.com/smart-mastering"><sm:source><sm:name>SOURCE2</sm:name><sm:import-id>mdm-import-b96735af-f7c3-4f95-9ea1-f884bc395e0f</sm:import-id><sm:user>admin</sm:user><sm:dateTime>{$s2-dt}</sm:dateTime></sm:source><sm:source><sm:name>SOURCE1</sm:name><sm:import-id>mdm-import-8cf89514-fb1d-45f1-b95f-8b69f3126f04</sm:import-id><sm:user>admin</sm:user><sm:dateTime>{$s1-dt}</sm:dateTime></sm:source></sm:sources></es:headers>
+  let $expected-headers :=
+    <es:headers>
+      <sm:id xmlns:sm="http://marklogic.com/smart-mastering">{$smid}</sm:id>
+      <sm:merges xmlns:sm="http://marklogic.com/smart-mastering">
+        <sm:document-uri>/source/2/doc2.xml</sm:document-uri>
+        <sm:document-uri>/source/1/doc1.xml</sm:document-uri>
+      </sm:merges>
+      <sm:sources xmlns:sm="http://marklogic.com/smart-mastering">
+        <sm:source>
+          <sm:name>SOURCE2</sm:name>
+          <sm:import-id>mdm-import-b96735af-f7c3-4f95-9ea1-f884bc395e0f</sm:import-id>
+          <sm:user>admin</sm:user>
+          <sm:dateTime>{$s2-dt}</sm:dateTime>
+        </sm:source>
+        <sm:source>
+          <sm:name>SOURCE1</sm:name>
+          <sm:import-id>mdm-import-8cf89514-fb1d-45f1-b95f-8b69f3126f04</sm:import-id>
+          <sm:user>admin</sm:user>
+          <sm:dateTime>{$s1-dt}</sm:dateTime>
+        </sm:source>
+      </sm:sources>
+    </es:headers>
   let $expected-instance := <es:instance><MDM><Person><PersonType><PersonName><PersonNameType><PersonSurName>JONES</PersonSurName><PersonGivenName>LINDSEY</PersonGivenName></PersonNameType></PersonName><Address><AddressType><LocationState>PA</LocationState><AddressPrivateMailboxText>45</AddressPrivateMailboxText><AddressSecondaryUnitText>JANA</AddressSecondaryUnitText><LocationPostalCode>18505</LocationPostalCode><LocationCityName>SCRANTON</LocationCityName></AddressType></Address><id>6270654339</id><id>6986792174</id><PersonBirthDate>19801001</PersonBirthDate><CaseAmount>1287.9</CaseAmount><CustomThing>2</CustomThing><CustomThing>1</CustomThing><PersonSSNIdentification><PersonSSNIdentificationType><IdentificationID>393225353</IdentificationID></PersonSSNIdentificationType></PersonSSNIdentification><Revenues><RevenuesType><Revenue>4332</Revenue></RevenuesType></Revenues><CaseStartDate>20110406</CaseStartDate><PersonSex>F</PersonSex></PersonType></Person></MDM></es:instance>
   let $expected-triples :=
     <es:triples>
@@ -70,8 +91,11 @@ let $assertions := xdmp:eager(
       </sem:triple>
     </es:triples>
   let $expected := <es:envelope xmlns:es="http://marklogic.com/entity-services">{$expected-headers}{$expected-triples}{$expected-instance}</es:envelope>
-  return
-    test:assert-equal-xml($expected, $merged-doc)
+  return (
+    test:assert-equal-xml($expected-headers, $merged-doc/es:headers),
+    test:assert-equal-xml($expected-triples, $merged-doc/es:triples),
+    test:assert-equal-xml($expected-instance, $merged-doc/es:instance)
+  )
 )
 
 let $merged-id := $merged-doc/es:headers/sm:id

--- a/src/test/ml-modules/root/test/suites/merging-xml/rollback-merge.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/rollback-merge.xqy
@@ -60,8 +60,57 @@ let $assertions := xdmp:eager(
           <sm:dateTime>{$s1-dt}</sm:dateTime>
         </sm:source>
       </sm:sources>
+      <custom xmlns:has="has">
+        <this><has:a><deep><path>deep value 2</path></deep></has:a></this>
+        <unconfigured>unconfigured value 2b</unconfigured>
+      </custom>
+      <custom xmlns:has="has">
+        <this><has:a><deep><path>deep value 1</path></deep></has:a></this>
+        <unconfigured>unconfigured value 1b</unconfigured>
+      </custom>
+      <shallow>shallow value 2</shallow>
+      <shallow>shallow value 1</shallow>
+      <es:unconfigured>unconfigured value 2a</es:unconfigured>
+      <es:unconfigured>unconfigured value 1a</es:unconfigured>
     </es:headers>
-  let $expected-instance := <es:instance><MDM><Person><PersonType><PersonName><PersonNameType><PersonSurName>JONES</PersonSurName><PersonGivenName>LINDSEY</PersonGivenName></PersonNameType></PersonName><Address><AddressType><LocationState>PA</LocationState><AddressPrivateMailboxText>45</AddressPrivateMailboxText><AddressSecondaryUnitText>JANA</AddressSecondaryUnitText><LocationPostalCode>18505</LocationPostalCode><LocationCityName>SCRANTON</LocationCityName></AddressType></Address><id>6270654339</id><id>6986792174</id><PersonBirthDate>19801001</PersonBirthDate><CaseAmount>1287.9</CaseAmount><CustomThing>2</CustomThing><CustomThing>1</CustomThing><PersonSSNIdentification><PersonSSNIdentificationType><IdentificationID>393225353</IdentificationID></PersonSSNIdentificationType></PersonSSNIdentification><Revenues><RevenuesType><Revenue>4332</Revenue></RevenuesType></Revenues><CaseStartDate>20110406</CaseStartDate><PersonSex>F</PersonSex></PersonType></Person></MDM></es:instance>
+  let $expected-instance :=
+    <es:instance>
+      <MDM>
+        <Person>
+          <PersonType>
+            <PersonName>
+              <PersonNameType>
+                <PersonSurName>JONES</PersonSurName>
+                <PersonGivenName>LINDSEY</PersonGivenName>
+              </PersonNameType>
+            </PersonName>
+            <Address>
+              <AddressType>
+                <LocationState>PA</LocationState>
+                <AddressPrivateMailboxText>45</AddressPrivateMailboxText>
+                <AddressSecondaryUnitText>JANA</AddressSecondaryUnitText>
+                <LocationPostalCode>18505</LocationPostalCode>
+                <LocationCityName>SCRANTON</LocationCityName>
+              </AddressType>
+            </Address>
+            <id>6270654339</id>
+            <id>6986792174</id>
+            <PersonBirthDate>19801001</PersonBirthDate>
+            <CaseAmount>1287.9</CaseAmount>
+            <CustomThing>2</CustomThing>
+            <CustomThing>1</CustomThing>
+            <PersonSSNIdentification>
+              <PersonSSNIdentificationType>
+                <IdentificationID>393225353</IdentificationID>
+              </PersonSSNIdentificationType>
+            </PersonSSNIdentification>
+            <Revenues><RevenuesType><Revenue>4332</Revenue></RevenuesType></Revenues>
+            <CaseStartDate>20110406</CaseStartDate>
+            <PersonSex>F</PersonSex>
+          </PersonType>
+        </Person>
+      </MDM>
+    </es:instance>
   let $expected-triples :=
     <es:triples>
       <sem:triple>

--- a/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
@@ -14,6 +14,7 @@ declare option xdmp:mapping "false";
 merging:save-options($lib:OPTIONS-NAME, test:get-test-file("merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-XQY, test:get-test-file("custom-xqy-merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-SJS, test:get-test-file("custom-sjs-merge-options.xml")),
+merging:save-options($lib:OPTIONS-NAME-PATH, test:get-test-file("path-merge-options.xml")),
 
 matcher:save-options($lib:OPTIONS-NAME-CUST-ACTION-XQY-MATCH, test:get-test-file("custom-xqy-action-match-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-ACTION-XQY-MERGE, test:get-test-file("custom-xqy-action-merge-options.xml")),
@@ -24,3 +25,4 @@ test:load-test-file("custom-merge-xqy.xqy", xdmp:modules-database(), "/custom-me
 test:load-test-file("custom-merge-sjs.sjs", xdmp:modules-database(), "/custom-merge-sjs.sjs"),
 test:load-test-file("custom-action-xqy.xqy", xdmp:modules-database(), "/custom-action.xqy"),
 test:load-test-file("custom-action-sjs.sjs", xdmp:modules-database(), "/custom-action.sjs")
+test:load-test-file("combine.xqy", xdmp:modules-database(), "/combine.xqy")

--- a/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
@@ -24,5 +24,5 @@ merging:save-options($lib:OPTIONS-NAME-CUST-ACTION-SJS-MERGE, test:get-test-file
 test:load-test-file("custom-merge-xqy.xqy", xdmp:modules-database(), "/custom-merge-xqy.xqy"),
 test:load-test-file("custom-merge-sjs.sjs", xdmp:modules-database(), "/custom-merge-sjs.sjs"),
 test:load-test-file("custom-action-xqy.xqy", xdmp:modules-database(), "/custom-action.xqy"),
-test:load-test-file("custom-action-sjs.sjs", xdmp:modules-database(), "/custom-action.sjs")
+test:load-test-file("custom-action-sjs.sjs", xdmp:modules-database(), "/custom-action.sjs"),
 test:load-test-file("combine.xqy", xdmp:modules-database(), "/combine.xqy")

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/combine.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/combine.xqy
@@ -10,15 +10,27 @@ declare function combine:combine(
 {
   let $values :=
     for $property in $properties
-    let $value := map:get($property, "values")
-    return $value
+    return map:get($property, "values")
   return
-    (: turn ("shallow value 1", "shallow value 2") into "shallow value 12" :)
-    fn:fold-left(
-      function($z, $a) {
-        $z || fn:replace($a, "[^\d]+", "")
-      },
-      fn:head($values),
-      fn:tail($values)
-    )
+    map:new((
+      map:entry("sources", $properties ! map:get(., "sources")),
+      map:entry("name", $property-name),
+      map:entry(
+        "values",
+        (: turn ("deep value 1", "deep value 2") into "deep value 12" :)
+        <path xmlns="" xmlns:has="has">
+          {
+            fn:fold-left(
+              function($z, $a) {
+                $z || fn:replace($a, "[^\d]+", "")
+              },
+              "deep value ",
+              for $v in $values
+              order by $v
+              return $v
+            )
+          }
+        </path>
+      )
+    ))
 };

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/combine.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/combine.xqy
@@ -1,0 +1,24 @@
+xquery version "1.0-ml";
+
+module namespace combine = "http://marklogic.com/smart-mastering/merging";
+
+declare function combine:combine(
+  $property-name as xs:QName,
+  $properties as map:map*,
+  $property-spec as element()?
+)
+{
+  let $values :=
+    for $property in $properties
+    let $value := map:get($property, "values")
+    return $value
+  return
+    (: turn ("shallow value 1", "shallow value 2") into "shallow value 12" :)
+    fn:fold-left(
+      function($z, $a) {
+        $z || fn:replace($a, "[^\d]+", "")
+      },
+      fn:head($values),
+      fn:tail($values)
+    )
+};

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc1.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc1.xml
@@ -12,8 +12,8 @@
     </smart-mastering:sources>
     <unconfigured>unconfigured value 1a</unconfigured>
     <shallow xmlns="">shallow value 1</shallow>
-    <custom xmlns="">
-      <this><has><a><deep><path>deep value 1</path></deep></a></has></this>
+    <custom xmlns="" xmlns:has="has">
+      <this><has:a><deep><path>deep value 1</path></deep></has:a></this>
       <unconfigured>unconfigured value 1b</unconfigured>
     </custom>
   </headers>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc1.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc1.xml
@@ -10,6 +10,12 @@
         <smart-mastering:dateTime>2018-04-26T16:40:02.1386Z</smart-mastering:dateTime>
       </smart-mastering:source>
     </smart-mastering:sources>
+    <unconfigured>unconfigured value 1a</unconfigured>
+    <shallow xmlns="">shallow value 1</shallow>
+    <custom xmlns="">
+      <this><has><a><deep><path>deep value 1</path></deep></a></has></this>
+      <unconfigured>unconfigured value 1b</unconfigured>
+    </custom>
   </headers>
   <triples xmlns:sem="http://marklogic.com/semantics">
     <sem:triple>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc2.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc2.xml
@@ -10,6 +10,12 @@
         <smart-mastering:dateTime>2018-04-26T16:40:16.760311Z</smart-mastering:dateTime>
       </smart-mastering:source>
     </smart-mastering:sources>
+    <unconfigured>unconfigured value 2a</unconfigured>
+    <shallow xmlns="">shallow value 2</shallow>
+    <custom xmlns="">
+      <this><has><a><deep><path>deep value 2</path></deep></a></has></this>
+      <unconfigured>unconfigured value 2b</unconfigured>
+    </custom>
   </headers>
   <triples xmlns:sem="http://marklogic.com/semantics">
     <sem:triple>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc2.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/doc2.xml
@@ -12,8 +12,8 @@
     </smart-mastering:sources>
     <unconfigured>unconfigured value 2a</unconfigured>
     <shallow xmlns="">shallow value 2</shallow>
-    <custom xmlns="">
-      <this><has><a><deep><path>deep value 2</path></deep></a></has></this>
+    <custom xmlns="" xmlns:has="has">
+      <this><has:a><deep><path>deep value 2</path></deep></has:a></this>
       <unconfigured>unconfigured value 2b</unconfigured>
     </custom>
   </headers>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/merge-options.xml
@@ -7,7 +7,6 @@
   </property-defs>
   <algorithms>
     <algorithm name="name" function="name"/>
-    <algorithm name="address" function="address"/>
   </algorithms>
   <merging>
     <merge property-name="ssn" algorithm-ref="user-defined">
@@ -21,12 +20,10 @@
       <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
       <length weight="8" />
     </merge>
-    <merge property-name="address" algorithm-ref="address" max-values="1">
-      <postal-code prefer="zip+4" />
-      <length weight="8" />
-      <double-metaphone>
-        <distance-threshold>50</distance-threshold>
-      </double-metaphone>
+    <merge property-name="address" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE2" weight="10"></source>
+      </source-weights>
     </merge>
   </merging>
 </options>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/path-merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/path-merge-options.xml
@@ -1,11 +1,11 @@
 <options xmlns="http://marklogic.com/smart-mastering/merging">
   <match-options>basic</match-options>
-  <property-defs>
+  <property-defs xmlns:es="http://marklogic.com/entity-services">
     <property namespace="" localname="IdentificationID" name="ssn"/>
     <property namespace="" localname="PersonName" name="name"/>
     <property namespace="" localname="Address" name="address"/>
-    <property path="/headers/shallow" name="shallow"/>
-    <property path="/headers/custom/this/has/a/deep/path" name="deep"/>
+    <property path="/es:headers/shallow" name="shallow"/>
+    <property path="/es:headers/custom/this/has/a/deep/path" name="deep"/>
   </property-defs>
   <algorithms>
     <algorithm name="name" function="name"/>
@@ -32,7 +32,6 @@
       </double-metaphone>
     </merge>
     <merge property-name="shallow" algorithm-ref="standard" max-values="1">
-    </merge>
       <source-weights>
         <source name="SOURCE1" weight="10"></source>
       </source-weights>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/path-merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/path-merge-options.xml
@@ -1,12 +1,16 @@
 <options xmlns="http://marklogic.com/smart-mastering/merging">
   <match-options>basic</match-options>
-  <property-defs xmlns:es="http://marklogic.com/entity-services">
-    <property namespace="" localname="IdentificationID" name="ssn"/>
-    <property namespace="" localname="PersonName" name="name"/>
-    <property namespace="" localname="Address" name="address"/>
-    <property path="/es:headers/shallow" name="shallow"/>
-    <property path="/es:headers/custom/this/has/a/deep/path" name="deep"/>
-  </property-defs>
+  <m:property-defs
+    xmlns:es="http://marklogic.com/entity-services"
+    xmlns:m="http://marklogic.com/smart-mastering/merging"
+    xmlns:has="has"
+    xmlns="">
+    <m:property namespace="" localname="IdentificationID" name="ssn"/>
+    <m:property namespace="" localname="PersonName" name="name"/>
+    <m:property namespace="" localname="Address" name="address"/>
+    <m:property path="/es:envelope/es:headers/shallow" name="shallow"/>
+    <m:property path="/es:envelope/es:headers/custom/this/has:a/deep/path" name="deep"/>
+  </m:property-defs>
   <algorithms>
     <algorithm name="name" function="name"/>
     <algorithm name="address" function="address"/>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/path-merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/path-merge-options.xml
@@ -1,0 +1,43 @@
+<options xmlns="http://marklogic.com/smart-mastering/merging">
+  <match-options>basic</match-options>
+  <property-defs>
+    <property namespace="" localname="IdentificationID" name="ssn"/>
+    <property namespace="" localname="PersonName" name="name"/>
+    <property namespace="" localname="Address" name="address"/>
+    <property path="/headers/shallow" name="shallow"/>
+    <property path="/headers/custom/this/has/a/deep/path" name="deep"/>
+  </property-defs>
+  <algorithms>
+    <algorithm name="name" function="name"/>
+    <algorithm name="address" function="address"/>
+    <algorithm name="combine" function="combine" namespace="http://marklogic.com/smart-mastering/merging" at="/combine.xqy" />
+  </algorithms>
+  <merging>
+    <merge property-name="ssn" algorithm-ref="user-defined">
+      <source-ref document-uri="docA" />
+    </merge>
+    <merge property-name="name"  max-values="1">
+      <double-metaphone>
+        <distance-threshold>50</distance-threshold>
+      </double-metaphone>
+      <synonyms-support>true</synonyms-support>
+      <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
+      <length weight="8" />
+    </merge>
+    <merge property-name="address" algorithm-ref="address" max-values="1">
+      <postal-code prefer="zip+4" />
+      <length weight="8" />
+      <double-metaphone>
+        <distance-threshold>50</distance-threshold>
+      </double-metaphone>
+    </merge>
+    <merge property-name="shallow" algorithm-ref="standard" max-values="1">
+    </merge>
+      <source-weights>
+        <source name="SOURCE1" weight="10"></source>
+      </source-weights>
+    </merge>
+    <merge property-name="deep" algorithm-ref="combine" max-values="1">
+    </merge>
+  </merging>
+</options>

--- a/src/test/ml-modules/root/test/suites/survivorship/standard-by-length.xqy
+++ b/src/test/ml-modules/root/test/suites/survivorship/standard-by-length.xqy
@@ -12,7 +12,7 @@ import module namespace std = "http://marklogic.com/smart-mastering/survivorship
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 
 let $property-spec :=
-  <merge property-name="name"  max-values="2" xmlns="http://marklogic.com/smart-mastering/survivorship/merging">
+  <merge property-name="name"  max-values="2" xmlns="http://marklogic.com/smart-mastering/merging">
     <length weight="8" />
     <source-weights>
       <source name="good-source" weight="1"/>

--- a/src/test/ml-modules/root/test/suites/survivorship/standard-by-source.xqy
+++ b/src/test/ml-modules/root/test/suites/survivorship/standard-by-source.xqy
@@ -12,7 +12,7 @@ import module namespace std = "http://marklogic.com/smart-mastering/survivorship
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 
 let $property-spec :=
-  <merge property-name="name"  max-values="2" xmlns="http://marklogic.com/smart-mastering/survivorship/merging">
+  <merge property-name="name"  max-values="2" xmlns="http://marklogic.com/smart-mastering/merging">
     <length weight="8" />
     <source-weights>
       <source name="good-source" weight="4"/>

--- a/src/test/ml-modules/root/test/suites/survivorship/test-data/sample-options.xml
+++ b/src/test/ml-modules/root/test/suites/survivorship/test-data/sample-options.xml
@@ -14,19 +14,12 @@
       <source-ref document-uri="docA" />
     </merge>
     <merge property-name="name"  max-values="1">
-      <double-metaphone>
-        <distance-threshold>50</distance-threshold>
-      </double-metaphone>
-      <synonyms-support>true</synonyms-support>
-      <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
       <length weight="8" />
     </merge>
-    <merge property-name="address" algorithm-ref="address" max-values="1">
-      <postal-code prefer="zip+4" />
-      <length weight="8" />
-      <double-metaphone>
-        <distance-threshold>50</distance-threshold>
-      </double-metaphone>
+    <merge property-name="address" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE2" weight="10"></source>
+      </source-weights>
     </merge>
   </merging>
 </options>


### PR DESCRIPTION
Allow configuration of properties by path. Paths must start with /es:envelope/es:headers. The usual algorithms are used for actual merging. 

This PR covers paths in XML. More to do to have it work on JSON, but a lot should be reusable. 