### PR TITLE
Fix XPath grouping to account for es:info under es:instance

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
@@ -17,7 +17,7 @@ import module namespace merge-impl = "http://marklogic.com/smart-mastering/survi
 declare option xdmp:mapping "false";
 
 declare function proc-impl:process-match-and-merge($uri as xs:string)
-  as element()*
+  as item()*
 {
   let $merging-options := merging:get-options($const:FORMAT-XML)
   return

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -796,7 +796,7 @@ declare function merge-impl:build-instance-body-by-final-properties(
 declare function merge-impl:get-instances($docs)
 {
   for $doc in $docs
-  let $instance := $doc/(es:envelope|object-node("envelope"))/(es:instance|object-node("instance"))/(*|object-node() except (es:info|object-node("info")))
+  let $instance := $doc/(es:envelope|object-node("envelope"))/(es:instance|object-node("instance"))/((*|object-node()) except (es:info|object-node("info")))
   return
     if ($instance instance of element(MDM)) then
       $instance/*/*

--- a/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc1.xml
+++ b/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc1.xml
@@ -13,6 +13,10 @@
   </headers>
   <triples/>
   <instance>
+    <info>
+      <title>MDM</title>
+      <version>1.0.0</version>
+    </info>
     <MDM xmlns="">
       <Person>
         <PersonType>

--- a/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc2.xml
+++ b/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc2.xml
@@ -13,6 +13,10 @@
   </headers>
   <triples/>
   <instance>
+    <info>
+      <title>MDM</title>
+      <version>1.0.0</version>
+    </info>
     <MDM xmlns="">
       <Person>
         <PersonType>

--- a/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc3.xml
+++ b/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc3.xml
@@ -13,6 +13,10 @@
   </headers>
   <triples/>
   <instance>
+    <info>
+      <title>MDM</title>
+      <version>1.0.0</version>
+    </info>
     <MDM xmlns="">
       <Person>
         <PersonType>

--- a/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc4.xml
+++ b/src/test/ml-modules/root/test/suites/match-and-merge/test-data/doc4.xml
@@ -29,6 +29,10 @@
     </sem:triple>
   </triples>
   <instance>
+    <info>
+      <title>MDM</title>
+      <version>1.0.0</version>
+    </info>
     <MDM xmlns="">
       <Manager>
         <ManagerType>


### PR DESCRIPTION
There was an issue with an XPath grouping that was leading to es:info not being excluded when retrieving an instance, leading to an error. Also, changed the proc-impl:process-match-and-merge#1 signature to return item()* since it is possible it can return JSON instead of elements.