### PR TITLE
Handle text nodes in history:normalize-value-for-tracing

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/auditing/history.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/auditing/history.xqy
@@ -114,9 +114,14 @@ declare function history:document-history($doc-uri as xs:string)
 
 declare function history:normalize-value-for-tracing($value as node())
 {
-  fn:normalize-space(
+  let $nodes := $value//(text()|number-node()|boolean-node())
+  let $nodes := if (fn:exists($nodes)) then
+    $nodes
+  else 
+    $value
+  return fn:normalize-space(
     fn:string-join(
-      for $node in $value//(text()|number-node()|boolean-node())
+      for $node in $nodes
       order by xdmp:key-from-QName(fn:node-name($node)), xdmp:key-from-QName(fn:node-name($node/..))
       return $node,
       " "

--- a/src/test/ml-modules/root/test/suites/auditing/property-history.xqy
+++ b/src/test/ml-modules/root/test/suites/auditing/property-history.xqy
@@ -14,8 +14,19 @@ declare variable $property-list := (
 
 declare option xdmp:mapping "false";
 
+let $assertions := ()
+
 let $merged-uri := cts:uris((), "limit=1", cts:collection-query($const:MERGED-COLL))
 let $actual as map:map := history:property-history($merged-uri)
-return (
+let $assertions := (
+  $assertions,
   test:assert-same-values($property-list, map:keys($actual))
 )
+
+(: normalize-value-for-tracing should not return empty for text nodes :)
+let $assertions := (
+  $assertions,
+  test:assert-equal('textValue', history:normalize-value-for-tracing(text{'textValue'}))
+)
+
+return $assertions


### PR DESCRIPTION
Fixes #108

It might be better to test this from a higher level with a JSON doc, but
I wasn't sure how to do that, so I just wrote a lower-level unit test