### PR TITLE
#146 Fix sm-match endpoint to cast rs:includeMatches param properly

### DIFF
--- a/src/main/ml-modules/services/sm-match.xqy
+++ b/src/main/ml-modules/services/sm-match.xqy
@@ -55,10 +55,15 @@ function post(
       $options//*:max-scan ! xs:integer(.),
       20
     ))
-  let $include-matches := 
-    if (map:get($params, "includeMatches") castable as xs:boolean) then
-      map:get($params, "includeMatches") cast as xs:boolean
-    else fn:false()
+  let $include-matches as xs:boolean := 
+    let $include := fn:head((map:get($params, "includeMatches"), fn:false()))
+    return
+      if ($include castable as xs:boolean) then
+        $include cast as xs:boolean
+      else 
+        fn:error((),"RESTAPI-SRVEXERR", 
+          (400, "Bad Request", 
+           "Your request included an invalid value for the includeMatches parameter.  A boolean value (true or false) is required."))
   let $results :=
     matcher:find-document-matches-by-options(
       $document,

--- a/src/main/ml-modules/services/sm-match.xqy
+++ b/src/main/ml-modules/services/sm-match.xqy
@@ -55,7 +55,10 @@ function post(
       $options//*:max-scan ! xs:integer(.),
       20
     ))
-  let $include-matches := fn:head((map:get($params, "includeMatches"), fn:false()))
+  let $include-matches := 
+    if (map:get($params, "includeMatches") castable as xs:boolean) then
+      map:get($params, "includeMatches") cast as xs:boolean
+    else fn:false()
   let $results :=
     matcher:find-document-matches-by-options(
       $document,


### PR DESCRIPTION
Tested via QConsole but couldn't figure out how to deploy to ensure it works as expected--gradle mlDeploy and mlLoadModules didn't push the new endpoint code.  Is there another way to do this in the future?