### PR TITLE
Mdm 349: control merging of nested properties

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/standard.xqy
@@ -31,7 +31,7 @@ declare function merging:standard(
     (
       let $length-weight :=
         fn:head((
-          $property-spec/m:length/@weight ! fn:number(.),
+          $property-spec/*:length/@weight ! fn:number(.),
           0
         ))
       for $property in merging:standard-condense-properties(
@@ -46,9 +46,11 @@ declare function merging:standard(
       let $source-score := fn:sum((
           for $source in $sources
           return
-            $property-spec
-              /m:source-weights
-              /m:source[@name = $source/name]/@weight
+            (: See MDM-529 for why the below is needed :)
+            fn:head((
+              $property-spec/*:source-weights/*:source[@name = $source/name]/@weight,
+              $property-spec/*:source-weights/*:source[*:name = $source/name]/*:weight
+            ))
         ))
       let $weight := $length-score + $source-score
       stable order by $weight descending, $source-dateTime descending

--- a/src/test/ml-modules/root/test/suites/merging-json/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/lib/lib.xqy
@@ -13,8 +13,20 @@ declare variable $TEST-DATA :=
     map:entry("/source/2/doc2.json", "doc2.json")
   ));
 
+declare variable $NESTED-DATA :=
+  map:new((
+    map:entry("/nested/doc1.json", "nested1.json"),
+    map:entry("/nested/doc2.json", "nested2.json")
+  ));
+
 declare variable $OPTIONS-NAME := "test-options";
 declare variable $OPTIONS-NAME-COMPLETE := "test-options-stock";
 declare variable $OPTIONS-NAME-CUST-XQY := "cust-xqy-test-options";
 declare variable $OPTIONS-NAME-CUST-SJS := "cust-sjs-test-options";
 declare variable $OPTIONS-NAME-PATH := "path-test-options";
+declare variable $NESTED-OPTIONS := "nested-options";
+
+declare function lib:take-strings($uris as xs:string*)
+{
+  $uris
+};

--- a/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
+++ b/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
@@ -5,8 +5,7 @@ const con = require("/com.marklogic.smart-mastering/constants.xqy");
 const test = require("/test/test-helper.xqy");
 const lib = require("lib/lib.xqy");
 
-let uris = [];
-for (uri in lib['NESTED-DATA']) { uris.push(uri); }
+let uris = ["/nested/doc1.json", "/nested/doc2.json"];
 let uriStr = uris.join('##');
 
 // Merge the nested docs
@@ -29,7 +28,7 @@ let mergedDoc =
     `,
     {
       "uri-str": uriStr,
-      "options-name": lib['NESTED-OPTIONS']
+      "options-name": "nested-options"
     },
     {
       "isolation": "different-transaction"

--- a/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
+++ b/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
@@ -38,6 +38,8 @@ let mergedDoc =
 [].concat(
   test.assertEqual("another string", mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty1.toString()),
   test.assertEqual("some string", mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty2.toString()),
-  // test.assertEqual("another string", mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty3.toString()),
+  test.assertEqual(2, mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty3.length),
+  test.assertEqual('another string 1', mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty3[0].toString()),
+  test.assertEqual('another string 2', mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty3[1].toString()),
   test.assertEqual(123, mergedDoc.envelope.instance.TopProperty.EntityReference.PropValue.valueOf())
 )

--- a/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
+++ b/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
@@ -1,0 +1,46 @@
+declareUpdate();
+
+const con = require("/com.marklogic.smart-mastering/constants.xqy");
+
+const test = require("/test/test-helper.xqy");
+const lib = require("lib/lib.xqy");
+
+let uris = [];
+for (uri in lib['NESTED-DATA']) { uris.push(uri); }
+let uriStr = uris.join('##');
+
+xdmp.log('merge-deeply-nested. uriStr=' + uriStr);
+
+// Merge the nested docs
+let mergedDoc =
+  fn.head(xdmp.xqueryEval(
+    `
+      import module namespace merging = "http://marklogic.com/smart-mastering/merging"
+        at "/com.marklogic.smart-mastering/merging.xqy";
+      import module namespace const = "http://marklogic.com/smart-mastering/constants"
+        at "/com.marklogic.smart-mastering/constants.xqy";
+      declare variable $uri-str as xs:string external;
+      declare variable $uris as xs:string* := fn:tokenize($uri-str, "##");
+      declare variable $options-name as xs:string external;
+
+      let $options as element() := merging:get-options($options-name, $const:FORMAT-XML)
+      return
+        merging:save-merge-models-by-uri(
+          $uris,
+          $options)
+    `,
+    {
+      "uri-str": uriStr,
+      "options-name": lib['NESTED-OPTIONS']
+    },
+    {
+      "isolation": "different-transaction"
+    }
+  ));
+
+[].concat(
+  test.assertEqual("another string", mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty1.toString()),
+  test.assertEqual("some string", mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty2.toString()),
+  // test.assertEqual("another string", mergedDoc.envelope.instance.TopProperty.LowerProperty1.EvenLowerProperty.LowestProperty3.toString()),
+  test.assertEqual(123, mergedDoc.envelope.instance.TopProperty.EntityReference.PropValue.valueOf())
+)

--- a/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
+++ b/src/test/ml-modules/root/test/suites/merging-json/merge-deeply-nested.sjs
@@ -9,8 +9,6 @@ let uris = [];
 for (uri in lib['NESTED-DATA']) { uris.push(uri); }
 let uriStr = uris.join('##');
 
-xdmp.log('merge-deeply-nested. uriStr=' + uriStr);
-
 // Merge the nested docs
 let mergedDoc =
   fn.head(xdmp.xqueryEval(

--- a/src/test/ml-modules/root/test/suites/merging-json/setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/setup.xqy
@@ -17,4 +17,14 @@ return
     $doc,
     xdmp:default-permissions(),
     $const:CONTENT-COLL
+  ),
+
+for $uri in map:keys($lib:NESTED-DATA)
+let $doc := test:get-test-file(map:get($lib:NESTED-DATA, $uri))
+return
+  xdmp:document-insert(
+    $uri,
+    $doc,
+    xdmp:default-permissions(),
+    $const:CONTENT-COLL
   )

--- a/src/test/ml-modules/root/test/suites/merging-json/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/suite-setup.xqy
@@ -13,6 +13,7 @@ merging:save-options($lib:OPTIONS-NAME-COMPLETE, test:get-test-file("merge-optio
 merging:save-options($lib:OPTIONS-NAME-CUST-XQY, test:get-test-file("custom-xqy-merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-SJS, test:get-test-file("custom-sjs-merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-PATH, test:get-test-file("path-merge-options.xml")),
+merging:save-options($lib:NESTED-OPTIONS, test:get-test-file("nested-merge-options.json")),
 
 test:load-test-file("custom-merge-xqy.xqy", xdmp:modules-database(), "/custom-merge-xqy.xqy"),
 test:load-test-file("custom-merge-sjs.sjs", xdmp:modules-database(), "/custom-merge-sjs.sjs"),

--- a/src/test/ml-modules/root/test/suites/merging-json/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/suite-teardown.xqy
@@ -1,7 +1,10 @@
 xquery version "1.0-ml";
 
-import module namespace merging = "http://marklogic.com/smart-mastering/survivorship/merging"
-  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
 
 (: Currently, there isn't a function to delete options. :)
-xdmp:directory-delete($merging:MERGING-OPTIONS-DIR)
+xdmp:collection-delete($const:OPTIONS-COLL),
+
+xdmp:collection-delete($const:ALGORITHM-COLL)
+

--- a/src/test/ml-modules/root/test/suites/merging-json/teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/teardown.xqy
@@ -9,6 +9,7 @@ declare option xdmp:mapping "false";
 
 xdmp:directory-delete("/source/"),
 xdmp:collection-delete($const:CONTENT-COLL),
+xdmp:collection-delete($const:ARCHIVED-COLL),
 xdmp:collection-delete($const:AUDITING-COLL),
 xdmp:collection-delete($const:MERGED-COLL),
 sem:graph-delete(sem:iri("http://marklogic.com/semantics#default-graph"))

--- a/src/test/ml-modules/root/test/suites/merging-json/test-data/nested-merge-options.json
+++ b/src/test/ml-modules/root/test/suites/merging-json/test-data/nested-merge-options.json
@@ -1,0 +1,74 @@
+{
+  "options": {
+    "matchOptions": "basic",
+    "propertyDefs": {
+      "properties": [
+        {
+          "namespace": "",
+          "localname": "LowerProperty1",
+          "name": "main"
+        },
+        {
+          "namespace": "",
+          "localname": "EntityReference",
+          "name": "entity"
+        },
+        {
+          "path": "/envelope/instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty1",
+          "name": "low1"
+        },
+        {
+          "path": "/envelope/instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty3",
+          "name": "low3"
+        }
+      ],
+      "namespaces": {
+      }
+    },
+    "algorithms": {
+      "stdAlgorithm": {}
+    },
+    "merging": [
+      {
+        "propertyName": "main",
+        "maxValues": "1",
+        "sourceWeights": {
+          "source": {
+            "name": "sample1",
+            "weight": "10"
+          }
+        }
+      },
+      {
+        "propertyName": "entity",
+        "maxValues": "1",
+        "sourceWeights": {
+          "source": {
+            "name": "sample1",
+            "weight": "10"
+          }
+        }
+      },
+      {
+        "propertyName": "low1",
+        "maxValues": "1",
+        "sourceWeights": {
+          "source": {
+            "name": "sample2",
+            "weight": "10"
+          }
+        }
+      },
+      {
+        "propertyName": "low3",
+        "maxValues": "1",
+        "sourceWeights": {
+          "source": {
+            "name": "sample2",
+            "weight": "10"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/test/ml-modules/root/test/suites/merging-json/test-data/nested1.json
+++ b/src/test/ml-modules/root/test/suites/merging-json/test-data/nested1.json
@@ -1,0 +1,40 @@
+{
+  "envelope": {
+    "headers": {
+      "id": [
+        "c14eebe0-1b7c-4c1a-96d9-65790d57cb1b"
+      ],
+      "sources": [
+        {
+          "name": "sample1",
+          "import-id": "",
+          "user": "mdm-rest-admin",
+          "dateTime": "2018-08-21T10:08:06.330137-04:00"
+        }
+      ]
+    },
+    "triple": [],
+    "instance": {
+      "info": {
+        "title": "Nested",
+        "version": "1.0.0"
+      },
+      "TopProperty": {
+        "LowerProperty1": {
+          "EvenLowerProperty": {
+            "LowestProperty1": "some string",
+            "LowestProperty2": "some string",
+            "LowestProperty3": [
+              "some string 1",
+              "some string 2"
+            ]
+          }
+        },
+        "EntityReference": {
+          "PropValue": 123
+        }
+      }
+    },
+    "attachments": []
+  }
+}

--- a/src/test/ml-modules/root/test/suites/merging-json/test-data/nested2.json
+++ b/src/test/ml-modules/root/test/suites/merging-json/test-data/nested2.json
@@ -1,0 +1,40 @@
+{
+  "envelope": {
+    "headers": {
+      "id": [
+        "fc0237d1-3df5-4a98-a1e5-9af881f6e6a7"
+      ],
+      "sources": [
+        {
+          "name": "sample2",
+          "import-id": "",
+          "user": "mdm-rest-admin",
+          "dateTime": "2018-08-21T10:08:06.330137-04:00"
+        }
+      ]
+    },
+    "triple": [],
+    "instance": {
+      "info": {
+        "title": "Nested",
+        "version": "1.0.0"
+      },
+      "TopProperty": {
+        "LowerProperty1": {
+          "EvenLowerProperty": {
+            "LowestProperty1": "another string",
+            "LowestProperty2": "another string",
+            "LowestProperty3": [
+              "another string 1",
+              "another string 2"
+            ]
+          }
+        },
+        "EntityReference": {
+          "PropValue": 123
+        }
+      }
+    },
+    "attachments": []
+  }
+}

--- a/src/test/ml-modules/root/test/suites/merging-xml/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/lib/lib.xqy
@@ -13,10 +13,18 @@ declare variable $TEST-DATA :=
     map:entry("/source/2/doc2.xml", "doc2.xml")
   ));
 
+declare variable $NESTED-DATA :=
+  map:new((
+    map:entry("/nested/doc1.xml", "nested1.xml"),
+    map:entry("/nested/doc2.xml", "nested2.xml")
+  ));
+
 declare variable $OPTIONS-NAME := "test-options";
 
 declare variable $ONE-FIRST-OPTIONS := "one-first-options";
 declare variable $TWO-FIRST-OPTIONS := "two-first-options";
+
+declare variable $NESTED-OPTIONS := "nested-options";
 
 declare variable $OPTIONS-NAME-CUST-XQY := "cust-xqy-test-options";
 declare variable $OPTIONS-NAME-CUST-SJS := "cust-sjs-test-options";

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
@@ -32,6 +32,6 @@ let $merged-doc :=
 return (
   test:assert-equal("another string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty1/fn:string()),
   test:assert-equal("some string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty2/fn:string()),
-  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty3/fn:string()),
+  test:assert-equal("another string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty3/fn:string()),
   test:assert-equal(123, $merged-doc/es:instance/TopProperty/EntityReference/PropValue/fn:data())
 )

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
@@ -4,8 +4,6 @@ import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace merging = "http://marklogic.com/smart-mastering/merging"
   at "/com.marklogic.smart-mastering/merging.xqy";
-import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
-  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
 
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
@@ -1,0 +1,38 @@
+xquery version "1.0-ml";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace merging = "http://marklogic.com/smart-mastering/merging"
+  at "/com.marklogic.smart-mastering/merging.xqy";
+import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
+  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+declare namespace es = "http://marklogic.com/entity-services";
+declare namespace sm = "http://marklogic.com/smart-mastering";
+declare namespace has = "has";
+
+(: Force update mode :)
+declare option xdmp:update "true";
+
+declare option xdmp:mapping "false";
+
+(: Merge the nested docs :)
+let $merged-doc :=
+  xdmp:invoke-function(
+    function() {
+      merging:save-merge-models-by-uri(
+        map:keys($lib:NESTED-DATA),
+        merging:get-options($lib:NESTED-OPTIONS, $const:FORMAT-XML))
+    },
+    $lib:INVOKE_OPTIONS
+  )
+
+return (
+  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty1/fn:string()),
+  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty2/fn:string()),
+  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty3/fn:string()),
+  test:assert-equal(123, $merged-doc/es:instance/TopProperty/EntityReference/PropValue/fn:data())
+)

--- a/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/merge-deeply-nested.xqy
@@ -11,8 +11,7 @@ import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
 declare namespace es = "http://marklogic.com/entity-services";
-declare namespace sm = "http://marklogic.com/smart-mastering";
-declare namespace has = "has";
+declare namespace nested = "nested";
 
 (: Force update mode :)
 declare option xdmp:update "true";
@@ -31,8 +30,8 @@ let $merged-doc :=
   )
 
 return (
-  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty1/fn:string()),
-  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty2/fn:string()),
-  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty3/fn:string()),
+  test:assert-equal("another string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty1/fn:string()),
+  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty2/fn:string()),
+  test:assert-equal("some string", $merged-doc/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty3/fn:string()),
   test:assert-equal(123, $merged-doc/es:instance/TopProperty/EntityReference/PropValue/fn:data())
 )

--- a/src/test/ml-modules/root/test/suites/merging-xml/setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/setup.xqy
@@ -17,4 +17,15 @@ return
     $doc,
     xdmp:default-permissions(),
     $const:CONTENT-COLL
+  ),
+
+for $uri in map:keys($lib:NESTED-DATA)
+let $doc := test:get-test-file(map:get($lib:NESTED-DATA, $uri))
+return
+  xdmp:document-insert(
+    $uri,
+    $doc,
+    xdmp:default-permissions(),
+    $const:CONTENT-COLL
   )
+

--- a/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
@@ -19,6 +19,7 @@ merging:save-options($lib:OPTIONS-NAME-CUST-TRIPS-SJS, test:get-test-file("custo
 merging:save-options($lib:OPTIONS-NAME-PATH, test:get-test-file("path-merge-options.xml")),
 merging:save-options($lib:ONE-FIRST-OPTIONS, test:get-test-file("one-first-options.xml")),
 merging:save-options($lib:TWO-FIRST-OPTIONS, test:get-test-file("two-first-options.xml")),
+merging:save-options($lib:NESTED-OPTIONS, test:get-test-file("nested-merge-options.xml")),
 
 matcher:save-options($lib:OPTIONS-NAME-CUST-ACTION-XQY-MATCH, test:get-test-file("custom-xqy-action-match-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-ACTION-XQY-MERGE, test:get-test-file("custom-xqy-action-merge-options.xml")),

--- a/src/test/ml-modules/root/test/suites/merging-xml/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/suite-teardown.xqy
@@ -1,7 +1,5 @@
 xquery version "1.0-ml";
 
-import module namespace merging = "http://marklogic.com/smart-mastering/survivorship/merging"
-  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
 import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 

--- a/src/test/ml-modules/root/test/suites/merging-xml/teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/teardown.xqy
@@ -9,6 +9,7 @@ declare option xdmp:mapping "false";
 
 xdmp:directory-delete("/source/"),
 xdmp:collection-delete($const:CONTENT-COLL),
+xdmp:collection-delete($const:ARCHIVED-COLL),
 xdmp:collection-delete($const:AUDITING-COLL),
 xdmp:collection-delete($const:MERGED-COLL),
 sem:graph-delete(sem:iri("http://marklogic.com/semantics#default-graph")),

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested-merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested-merge-options.xml
@@ -5,7 +5,8 @@
     xmlns:nested="nested">
     <property namespace="nested" localname="LowerProperty1" name="main"/>
     <property namespace="" localname="EntityReference" name="entity"/>
-    <property path="/es:envelope/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty1" name="low"/>
+    <property path="/es:envelope/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty1" name="low1"/>
+    <property path="/es:envelope/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty3" name="low3"/>
   </property-defs>
   <algorithms>
     <!-- config for standard algorithm -->
@@ -24,7 +25,12 @@
         <source name="sample1" weight="10"/>
       </source-weights>
     </merge>
-    <merge property-name="low"  max-values="1">
+    <merge property-name="low1"  max-values="1">
+      <source-weights>
+        <source name="sample2" weight="10"/>
+      </source-weights>
+    </merge>
+    <merge property-name="low3"  max-values="1">
       <source-weights>
         <source name="sample2" weight="10"/>
       </source-weights>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested-merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested-merge-options.xml
@@ -1,0 +1,35 @@
+<options xmlns="http://marklogic.com/smart-mastering/merging">
+  <match-options>basic</match-options>
+  <property-defs xmlns:es="http://marklogic.com/entity-services">
+    <property namespace="" localname="LowerProperty1" name="main"/>
+    <property namespace="" localname="EntityReference" name="entity"/>
+    <!--
+    <property path="/es:envelope/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty1" name="low"/>
+    -->
+  </property-defs>
+  <algorithms>
+    <!-- config for standard algorithm -->
+    <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
+      <timestamp path="/es:envelope/es:headers/sm:sources/sm:source/sm:dateTime" />
+    </std-algorithm>
+  </algorithms>
+  <merging>
+    <merge property-name="main" max-values="1">
+      <source-weights>
+        <source name="sample1" weight="10"/>
+      </source-weights>
+    </merge>
+    <merge property-name="entity" max-values="1">
+      <source-weights>
+        <source name="sample1" weight="10"/>
+      </source-weights>
+    </merge>
+    <!--
+    <merge property-name="low"  max-values="1">
+      <source-weights>
+        <source name="sample2" weight="10"/>
+      </source-weights>
+    </merge>
+    -->
+  </merging>
+</options>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested-merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested-merge-options.xml
@@ -1,11 +1,11 @@
 <options xmlns="http://marklogic.com/smart-mastering/merging">
   <match-options>basic</match-options>
-  <property-defs xmlns:es="http://marklogic.com/entity-services">
-    <property namespace="" localname="LowerProperty1" name="main"/>
+  <property-defs
+    xmlns:es="http://marklogic.com/entity-services"
+    xmlns:nested="nested">
+    <property namespace="nested" localname="LowerProperty1" name="main"/>
     <property namespace="" localname="EntityReference" name="entity"/>
-    <!--
-    <property path="/es:envelope/es:instance/TopProperty/LowerProperty1/EvenLowerProperty/LowestProperty1" name="low"/>
-    -->
+    <property path="/es:envelope/es:instance/TopProperty/nested:LowerProperty1/EvenLowerProperty/LowestProperty1" name="low"/>
   </property-defs>
   <algorithms>
     <!-- config for standard algorithm -->
@@ -24,12 +24,10 @@
         <source name="sample1" weight="10"/>
       </source-weights>
     </merge>
-    <!--
     <merge property-name="low"  max-values="1">
       <source-weights>
         <source name="sample2" weight="10"/>
       </source-weights>
     </merge>
-    -->
   </merging>
 </options>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested1.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested1.xml
@@ -17,13 +17,13 @@
       <es:version>1.0</es:version>
     </es:info>
     <TopProperty>
-      <LowerProperty1>
+      <nested:LowerProperty1 xmlns:nested="nested">
         <EvenLowerProperty>
           <LowestProperty1>some string</LowestProperty1>
           <LowestProperty2>some string</LowestProperty2>
           <LowestProperty3>some string</LowestProperty3>
         </EvenLowerProperty>
-      </LowerProperty1>
+      </nested:LowerProperty1>
       <EntityReference>
         <PropValue>123</PropValue>
       </EntityReference>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested1.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested1.xml
@@ -1,0 +1,34 @@
+<es:envelope xmlns:es="http://marklogic.com/entity-services">
+  <es:headers>
+    <sm:id xmlns:sm="http://marklogic.com/smart-mastering">c14eebe0-1b7c-4c1a-96d9-65790d57cb1b</sm:id>
+    <sm:sources xmlns:sm="http://marklogic.com/smart-mastering">
+      <sm:source>
+        <sm:name>sample1</sm:name>
+        <sm:import-id></sm:import-id>
+        <sm:user>mdm-rest-admin</sm:user>
+        <sm:dateTime>2018-08-21T10:08:06.330137-04:00</sm:dateTime>
+      </sm:source>
+    </sm:sources>
+  </es:headers>
+  <es:triples></es:triples>
+  <es:instance>
+    <es:info>
+      <es:title>Nested</es:title>
+      <es:version>1.0</es:version>
+    </es:info>
+    <TopProperty>
+      <LowerProperty1>
+        <EvenLowerProperty>
+          <LowestProperty1>some string</LowestProperty1>
+          <LowestProperty2>some string</LowestProperty2>
+          <LowestProperty3>some string</LowestProperty3>
+        </EvenLowerProperty>
+      </LowerProperty1>
+      <EntityReference>
+        <PropValue>123</PropValue>
+      </EntityReference>
+    </TopProperty>
+  </es:instance>
+  <es:attachments>
+  </es:attachments>
+</es:envelope>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested2.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested2.xml
@@ -1,6 +1,6 @@
 <es:envelope xmlns:es="http://marklogic.com/entity-services">
   <es:headers>
-    <sm:id xmlns:sm="http://marklogic.com/smart-mastering">c14eebe0-1b7c-4c1a-96d9-65790d57cb1b</sm:id>
+    <sm:id xmlns:sm="http://marklogic.com/smart-mastering">fc0237d1-3df5-4a98-a1e5-9af881f6e6a7</sm:id>
     <sm:sources xmlns:sm="http://marklogic.com/smart-mastering">
       <sm:source>
         <sm:name>sample2</sm:name>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested2.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested2.xml
@@ -1,0 +1,34 @@
+<es:envelope xmlns:es="http://marklogic.com/entity-services">
+  <es:headers>
+    <sm:id xmlns:sm="http://marklogic.com/smart-mastering">c14eebe0-1b7c-4c1a-96d9-65790d57cb1b</sm:id>
+    <sm:sources xmlns:sm="http://marklogic.com/smart-mastering">
+      <sm:source>
+        <sm:name>sample2</sm:name>
+        <sm:import-id></sm:import-id>
+        <sm:user>mdm-rest-admin</sm:user>
+        <sm:dateTime>2018-08-21T10:08:06.330137-04:00</sm:dateTime>
+      </sm:source>
+    </sm:sources>
+  </es:headers>
+  <es:triples></es:triples>
+  <es:instance>
+    <es:info>
+      <es:title>Nested</es:title>
+      <es:version>1.0</es:version>
+    </es:info>
+    <TopProperty>
+      <LowerProperty1>
+        <EvenLowerProperty>
+          <LowestProperty1>another string</LowestProperty1>
+          <LowestProperty2>another string</LowestProperty2>
+          <LowestProperty3>another string</LowestProperty3>
+        </EvenLowerProperty>
+      </LowerProperty1>
+      <EntityReference>
+        <PropValue>456</PropValue>
+      </EntityReference>
+    </TopProperty>
+  </es:instance>
+  <es:attachments>
+  </es:attachments>
+</es:envelope>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested2.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/nested2.xml
@@ -17,13 +17,13 @@
       <es:version>1.0</es:version>
     </es:info>
     <TopProperty>
-      <LowerProperty1>
+      <nested:LowerProperty1 xmlns:nested="nested">
         <EvenLowerProperty>
           <LowestProperty1>another string</LowestProperty1>
           <LowestProperty2>another string</LowestProperty2>
           <LowestProperty3>another string</LowestProperty3>
         </EvenLowerProperty>
-      </LowerProperty1>
+      </nested:LowerProperty1>
       <EntityReference>
         <PropValue>456</PropValue>
       </EntityReference>

--- a/src/test/ml-modules/root/test/suites/survivorship/standard-by-length.xqy
+++ b/src/test/ml-modules/root/test/suites/survivorship/standard-by-length.xqy
@@ -39,9 +39,9 @@ let $source3 :=
   }
 
 let $wrapped-properties := (
-  merging-impl:wrap-revision-info(xs:QName("name"), <name>A</name>, $source1),
-  merging-impl:wrap-revision-info(xs:QName("name"), <name>AA</name>, $source2),
-  merging-impl:wrap-revision-info(xs:QName("name"), <name>AAA</name>, $source3)
+  merging-impl:wrap-revision-info(xs:QName("name"), <name>A</name>, $source1, (), ()),
+  merging-impl:wrap-revision-info(xs:QName("name"), <name>AA</name>, $source2, (), ()),
+  merging-impl:wrap-revision-info(xs:QName("name"), <name>AAA</name>, $source3, (), ())
 )
 let $actual :=
   std:standard(xs:QName("name"), $wrapped-properties, $property-spec)

--- a/src/test/ml-modules/root/test/suites/survivorship/standard-by-source.xqy
+++ b/src/test/ml-modules/root/test/suites/survivorship/standard-by-source.xqy
@@ -39,9 +39,9 @@ let $source3 :=
   }
 
 let $wrapped-properties := (
-  merging-impl:wrap-revision-info(xs:QName("name"), <name>Name1</name>, $source1),
-  merging-impl:wrap-revision-info(xs:QName("name"), <name>Name2</name>, $source2),
-  merging-impl:wrap-revision-info(xs:QName("name"), <name>Name3</name>, $source3)
+  merging-impl:wrap-revision-info(xs:QName("name"), <name>Name1</name>, $source1, (), ()),
+  merging-impl:wrap-revision-info(xs:QName("name"), <name>Name2</name>, $source2, (), ()),
+  merging-impl:wrap-revision-info(xs:QName("name"), <name>Name3</name>, $source3, (), ())
 )
 let $actual :=
   std:standard(xs:QName("name"), $wrapped-properties, $property-spec)


### PR DESCRIPTION
- allow configuration to specify merging of deeply nested properties, not just top-level ones
- made the standard algorithm a little more flexible to allow for extracting config from JSON format; filed bug for more thoughtful fix