### PR TITLE
Mdm 504

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
@@ -76,10 +76,10 @@ declare function match-impl:find-document-matches-by-options(
       $options
   let $scoring := $options/matcher:scoring
   let $algorithms := algorithms:build-algorithms-map($options/matcher:algorithms)
-  let $query := match-impl:build-query($document, $scoring, $algorithms, $options)
-  let $serialized-query := element boost-query {$query}
+  let $boost-query := match-impl:build-boost-query($document, $scoring, $algorithms, $options)
+  let $serialized-boost-query := element boost-query {$boost-query}
   let $minimum-threshold-combinations :=
-    match-impl:minimum-threshold-combinations($serialized-query, $minimum-threshold)
+    match-impl:minimum-threshold-combinations($serialized-boost-query, $minimum-threshold)
   let $match-query :=
     cts:and-query((
       cts:collection-query($const:CONTENT-COLL),
@@ -100,7 +100,7 @@ declare function match-impl:find-document-matches-by-options(
     }
   let $reduced-boost := cts:query(
     element cts:or-query {
-      $serialized-query/cts:or-query/element(*, cts:query)
+      $serialized-boost-query/cts:or-query/element(*, cts:query)
     }
   )
   let $_lock-on-search :=
@@ -212,7 +212,7 @@ declare function match-impl:drop-redundant($uri, $matches as element(result)*)
  : @param $options  full match options; included here to pass into algorithm functions
  : @return a cts:or-query that will be used as a boost query
  :)
-declare function match-impl:build-query($document, $scoring, $algorithms, $options)
+declare function match-impl:build-boost-query($document, $scoring, $algorithms, $options)
 {
   let $property-defs := $options/matcher:property-defs
   return
@@ -223,7 +223,7 @@ declare function match-impl:build-query($document, $scoring, $algorithms, $optio
       where fn:exists($property-def)
       return
         let $qname := fn:QName($property-def/@namespace, $property-def/@localname)
-        let $values := $document//*[fn:node-name(.) eq $qname] ! fn:normalize-space(.)[.]
+        let $values := fn:distinct-values($document//*[fn:node-name(.) eq $qname] ! fn:normalize-space(.)[.])
         let $is-json := fn:exists(($document/object-node(), $document/array-node()))
         where fn:exists($values)
         return

--- a/src/test/ml-modules/root/test/suites/org-match/boost-query.xqy
+++ b/src/test/ml-modules/root/test/suites/org-match/boost-query.xqy
@@ -16,9 +16,10 @@ let $actual :=
     fn:true(),
     cts:collection-query($lib:ORG-COLL)
 )
-let $_ := xdmp:log("boost-query. actual=" || xdmp:quote($actual))
+let $org-name-query := $actual/boost-query/cts:or-query/cts:json-property-value-query[./cts:property = "orgName"]
 return (
   test:assert-equal(1, $actual/@total/fn:data()),
   test:assert-equal(1, fn:count($actual/result)),
-  test:assert-equal(30, $actual/result/@score/fn:data())
+  test:assert-equal(30, $actual/result/@score/fn:data()),
+  test:assert-equal(1, fn:count(fn:distinct-values($org-name-query/cts:value/fn:string())))
 )

--- a/src/test/ml-modules/root/test/suites/org-match/boost-query.xqy
+++ b/src/test/ml-modules/root/test/suites/org-match/boost-query.xqy
@@ -1,0 +1,24 @@
+xquery version "1.0-ml";
+
+(:
+ : Purpose of test: see MDM-491. Boost query was being generated incorrectly.
+ :)
+
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
+  at "/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+let $actual :=
+  matcher:find-document-matches-by-options-name(
+    fn:doc($lib:URI1),
+    $lib:MATCH-OPTIONS-NAME,
+    fn:true(),
+    cts:collection-query($lib:ORG-COLL)
+)
+let $_ := xdmp:log("boost-query. actual=" || xdmp:quote($actual))
+return (
+  test:assert-equal(1, $actual/@total/fn:data()),
+  test:assert-equal(1, fn:count($actual/result)),
+  test:assert-equal(30, $actual/result/@score/fn:data())
+)

--- a/src/test/ml-modules/root/test/suites/org-match/boost-query.xqy
+++ b/src/test/ml-modules/root/test/suites/org-match/boost-query.xqy
@@ -1,7 +1,8 @@
 xquery version "1.0-ml";
 
 (:
- : Purpose of test: see MDM-491. Boost query was being generated incorrectly.
+ : Purpose of test: see MDM-491. Boost query was being generated incorrectly, resulting in extra points being awarded
+ : to a match (score of 50 instead of 30).
  :)
 
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";

--- a/src/test/ml-modules/root/test/suites/org-match/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/org-match/lib/lib.xqy
@@ -1,0 +1,17 @@
+xquery version "1.0-ml";
+
+module namespace lib = "http://marklogic.com/smart-mastering/test";
+
+declare variable $URI1 := "/source/1/org1.json";
+declare variable $URI2 := "/source/2/orgA.json";
+
+
+declare variable $TEST-DATA :=
+  map:new((
+    map:entry($URI1, "org1.json"),
+    map:entry($URI2, "orgA.json")
+  ));
+
+declare variable $MATCH-OPTIONS-NAME := "org-match-options";
+
+declare variable $ORG-COLL := "Organization";

--- a/src/test/ml-modules/root/test/suites/org-match/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/org-match/suite-setup.xqy
@@ -1,0 +1,22 @@
+xquery version "1.0-ml";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
+  at "/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare option xdmp:mapping "false";
+
+matcher:save-options($lib:MATCH-OPTIONS-NAME, test:get-test-file("org-match-options.xml")),
+
+for $uri in map:keys($lib:TEST-DATA)
+let $doc := test:get-test-file(map:get($lib:TEST-DATA, $uri))
+return
+  xdmp:document-insert(
+    $uri,
+    $doc,
+    xdmp:default-permissions(),
+    ($const:CONTENT-COLL, $lib:ORG-COLL)
+  )

--- a/src/test/ml-modules/root/test/suites/org-match/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/org-match/suite-teardown.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+declare option xdmp:mapping "false";
+
+xdmp:collection-delete($const:OPTIONS-COLL),
+
+map:keys($lib:TEST-DATA) ! xdmp:document-delete(.)

--- a/src/test/ml-modules/root/test/suites/org-match/test-data/org-match-options.xml
+++ b/src/test/ml-modules/root/test/suites/org-match/test-data/org-match-options.xml
@@ -1,0 +1,26 @@
+<options xmlns="http://marklogic.com/smart-mastering/matcher">
+  <property-defs>
+    <property namespace="" localname="orgName" name="name"/>
+    <property namespace="" localname="structure" name="structure"/>
+    <property namespace="" localname="purpose" name="purpose"/>
+  </property-defs>
+  <algorithms>
+    <algorithm name="dbl-metaphone" function="double-metaphone"/>
+  </algorithms>
+  <scoring>
+    <add property-name="name" weight="20"/>
+    <add property-name="structure" weight="5"/>
+    <add property-name="purpose" weight="5"/>
+    <expand property-name="name" algorithm-ref="dbl-metaphone" weight="5">
+      <distance-threshold>50</distance-threshold>
+    </expand>
+  </scoring>
+  <thresholds>
+    <threshold above="15" label="Likely Match" action="notify"/>
+    <threshold above="30" label="Definitive Match" action="merge"/>
+  </thresholds>
+  <tuning>
+    <max-scan>200</max-scan>  <!-- never look at more than 200 -->
+    <initial-scan>20</initial-scan>
+  </tuning>
+</options>

--- a/src/test/ml-modules/root/test/suites/org-match/test-data/org1.json
+++ b/src/test/ml-modules/root/test/suites/org-match/test-data/org1.json
@@ -1,0 +1,56 @@
+{
+  "envelope": {
+    "headers": {
+      "id": "791060a1-b5ef-46c0-9fcd-962de2986a7f",
+      "sources": {
+        "source": {
+          "name": "/Organizations/Source1/org1.json",
+          "user": "mdm-rest-admin",
+          "dateTime": "2018-09-10T16:09:34.018443-04:00"
+        }
+      }
+    },
+    "triples": [],
+    "instance": {
+      "Organization": {
+        "orgName": "Besto",
+        "structure": "C Corp",
+        "purpose": "For Profit"
+      },
+      "info": {
+        "title": "Organization",
+        "version": "0.0.1"
+      }
+    },
+    "attachments": {
+      "organization": {
+        "orgName": "Besto",
+        "type": "For Profit",
+        "form": "C Corp",
+        "mission": "Excepteur deserunt proident consectetur fugiat. Proident nostrud pariatur elit ipsum exercitation reprehenderit dolor aliqua. Aliquip id anim incididunt consectetur id tempor ad nulla eiusmod anim esse magna.",
+        "offices": [
+          {
+            "officeName": "Adipisicing",
+            "phone": "+1 (893) 576-2744",
+            "address": "897 Bryant Street, Gilmore, Delaware, 5147"
+          },
+          {
+            "officeName": "Excepteur",
+            "phone": "+1 (829) 478-3966",
+            "address": "257 Taylor Street, Chaparrito, Oregon, 6645"
+          },
+          {
+            "officeName": "Consectetur",
+            "phone": "+1 (973) 443-3885",
+            "address": "799 Woodruff Avenue, Carlos, Georgia, 8306"
+          },
+          {
+            "officeName": "Velit",
+            "phone": "+1 (938) 491-3184",
+            "address": "882 Howard Alley, Martell, North Dakota, 554"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/org-match/test-data/orgA.json
+++ b/src/test/ml-modules/root/test/suites/org-match/test-data/orgA.json
@@ -1,0 +1,35 @@
+{
+  "envelope": {
+    "headers": {
+      "id": "6ec353d8-5010-44e8-9628-f25fce29e2f5",
+      "sources": {
+        "source": {
+          "name": "/Organizations/Source2/orgA.json",
+          "user": "mdm-rest-admin",
+          "dateTime": "2018-09-10T16:09:36.184582-04:00"
+        }
+      }
+    },
+    "triples": [],
+    "instance": {
+      "Organization": {
+        "orgName": "Besto",
+        "structure": "C Corp",
+        "purpose": "For Profit"
+      },
+      "info": {
+        "title": "Organization",
+        "version": "0.0.1"
+      }
+    },
+    "attachments": {
+      "org": {
+        "companyName": "Besto",
+        "intent": "For Profit",
+        "taxStructure": "subchapter-c corporation",
+        "missionStatement": "In minim sunt ipsum reprehenderit do. Culpa incididunt enim est elit. Consequat culpa ipsum reprehenderit eu. Adipisicing amet dolor sit nisi anim pariatur. Aliqua labore dolor aliqua anim eu ipsum fugiat cillum id velit aliqua.",
+        "primaryPhone": "+1 (922) 599-3216"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixing a bug that awarded too high of a score during matching. Happened when the harmonized and original element/property name were the same, so the value came back twice. 