### PR TITLE
Update testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,13 @@ buildscript {
   repositories {
     jcenter()
 
-    // Needed for ml-unit-test-client dependency until it's available via jcenter()
+    // Needed for marklogic-unit-test-client dependency until it's available via jcenter()
     maven {
-      url {"https://dl.bintray.com/rjrudin/maven/"}
+      url {"https://dl.bintray.com/marklogic-community/Maven"}
     }
   }
   dependencies {
-    classpath "com.marklogic:ml-unit-test-client:0.11.1"
+    classpath "com.marklogic:marklogic-unit-test-client:0.12.0"
     classpath "com.marklogic:ml-gradle:${mlGradleVersion}"
   }
 }
@@ -24,17 +24,17 @@ plugins {
 repositories {
   jcenter()
 
-  // Needed for ml-unit-test and ml-unit-test-client dependencies until they're available via jcenter()
+  // Needed for marklogic-unit-test and marklogic-unit-test-client dependencies until they're available via jcenter()
   maven {
-    url {"https://dl.bintray.com/rjrudin/maven/"}
+    url {"https://dl.bintray.com/marklogic-community/Maven"}
   }
 }
 
 dependencies {
-  mlRestApi "com.marklogic:ml-unit-test-modules:0.11.1"
+  mlRestApi "com.marklogic:marklogic-unit-test-modules:0.12.0"
 
-  // For running ml-unit-test tests via JUnit
-  testCompile "com.marklogic:ml-unit-test-client:0.11.1"
+  // For running marklogic-unit-test tests via JUnit
+  testCompile "com.marklogic:marklogic-unit-test-client:0.12.0"
   testCompile "junit:junit:4+"
 }
 

--- a/src/test/ml-modules/root/test/suites/merging-json/json-options-round-trip.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/json-options-round-trip.xqy
@@ -34,6 +34,6 @@ declare variable $options := test:get-test-file("merge-options.json")/node();
 let $actual := merging:get-options("json-options", $const:FORMAT-JSON)
 return test:assert-equal-json($options, $actual),
 
-let $expected := test:get-test-file("merge-options.json")
+let $expected := test:get-test-file("merge-options.json")/node()
 let $actual := merging:get-options($lib:OPTIONS-NAME-COMPLETE, $const:FORMAT-JSON)
 return test:assert-equal-json($expected, $actual)


### PR DESCRIPTION
- Update to marklogic-unit-test v0.12.0, now published under marklogic-community
- new version of test framework is more specific, so updated one test