### PR TITLE
MDM-490 Restrict matches to within instance

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/constants.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/constants.xqy
@@ -52,3 +52,7 @@ declare variable $TRACE-MATCH-RESULTS := "SM-MATCH";
 
 (: ERRORS :)
 declare variable $NO-MERGE-OPTIONS-ERROR := xs:QName("SM-NO-MERGING-OPTIONS");
+
+(: Scope for instance bodies :)
+declare variable $JSON-INSTANCE as xs:string? := "instance";
+declare variable $XML-INSTANCE as xs:QName? := fn:QName("http://marklogic.com/entity-services", "instance");

--- a/src/test/ml-modules/root/test/suites/matching/find-document-matches-by-options-name.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/find-document-matches-by-options-name.xqy
@@ -19,18 +19,18 @@ let $actual := matcher:find-document-matches-by-options-name($doc, $lib:MATCH-OP
 return (
   let $def-match := $actual/result[@threshold="Definitive Match"]
   return (
-    test:assert-same-values(($lib:URI3, $lib:URI5, $lib:URI6) ! attribute uri {.}, $def-match/@uri),
-    test:assert-equal(3, fn:count($def-match/@threshold[. = "Definitive Match"])),
-    test:assert-equal(3, fn:count($def-match/@action[. = $constants:MERGE-ACTION])),
+    test:assert-same-values(($lib:URI3) ! attribute uri {.}, $def-match/@uri),
+    test:assert-equal(1, fn:count($def-match/@threshold[. = "Definitive Match"])),
+    test:assert-equal(1, fn:count($def-match/@action[. = $constants:MERGE-ACTION])),
     test:assert-not-exists($def-match/matches),
     test:assert-equal($telemetry-count + 1, tel:get-usage-count())
   ),
 
   let $likely-match := $actual/result[@threshold="Likely Match"]
   return (
-    test:assert-same-values(($lib:URI1, $lib:URI4) ! attribute uri {.}, $likely-match/@uri),
-    test:assert-equal(2, fn:count($likely-match/@threshold[. = "Likely Match"])),
-    test:assert-equal(2, fn:count($likely-match/@action[. = $constants:NOTIFY-ACTION])),
+    test:assert-same-values(($lib:URI1) ! attribute uri {.}, $likely-match/@uri),
+    test:assert-equal(1, fn:count($likely-match/@threshold[. = "Likely Match"])),
+    test:assert-equal(1, fn:count($likely-match/@action[. = $constants:NOTIFY-ACTION])),
     test:assert-not-exists($likely-match/matches)
   )
 )

--- a/src/test/ml-modules/root/test/suites/matching/include-matches.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/include-matches.xqy
@@ -15,18 +15,18 @@ let $actual := matcher:find-document-matches-by-options-name($doc, $lib:MATCH-OP
 return (
   let $def-match := $actual/result[@threshold="Definitive Match"]
   return (
-    test:assert-same-values(($lib:URI3, $lib:URI5, $lib:URI6) ! attribute uri {.}, $def-match/@uri),
-    test:assert-equal(3, fn:count($def-match/@threshold[. = "Definitive Match"])),
-    test:assert-equal(3, fn:count($def-match/@action[. = $constants:MERGE-ACTION])),
+    test:assert-same-values(($lib:URI3) ! attribute uri {.}, $def-match/@uri),
+    test:assert-equal(1, fn:count($def-match/@threshold[. = "Definitive Match"])),
+    test:assert-equal(1, fn:count($def-match/@action[. = $constants:MERGE-ACTION])),
     test:assert-exists($def-match/matches),
     test:assert-equal(6, fn:count($def-match/matches/node()))
   ),
 
   let $likely-match := $actual/result[@threshold="Likely Match"]
   return (
-    test:assert-same-values(($lib:URI1, $lib:URI4) ! attribute uri {.}, $likely-match/@uri),
-    test:assert-equal(2, fn:count($likely-match/@threshold[. = "Likely Match"])),
-    test:assert-equal(2, fn:count($likely-match/@action[. = $constants:NOTIFY-ACTION])),
+    test:assert-same-values(($lib:URI1) ! attribute uri {.}, $likely-match/@uri),
+    test:assert-equal(1, fn:count($likely-match/@threshold[. = "Likely Match"])),
+    test:assert-equal(1, fn:count($likely-match/@action[. = $constants:NOTIFY-ACTION])),
     test:assert-exists($likely-match/matches),
     test:assert-equal(3, fn:count($likely-match/matches/node()))
   )

--- a/src/test/ml-modules/root/test/suites/matching/match-response.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/match-response.xqy
@@ -108,9 +108,9 @@ return (
   return (
     test:assert-true($actual instance of element(results)),
     test:assert-equal(6, $actual/@page-length/xs:int(.)),
-    test:assert-equal(5, fn:count($actual/result)),
+    test:assert-equal(2, fn:count($actual/result)),
     test:assert-equal(1, $actual/@start/xs:int(.)),
-    test:assert-equal(5, $actual/@total/xs:int(.)),
+    test:assert-equal(2, $actual/@total/xs:int(.)),
     test:assert-not-exists($actual/result/@total),
     for $r at $i in $actual/result
     order by $r/@index/xs:int(.) ascending
@@ -119,13 +119,13 @@ return (
   ),
 
   (: test page length < # of results :)
-  let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 2, fn:true(), cts:true-query())
+  let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 1, fn:true(), cts:true-query())
   return (
     test:assert-true($actual instance of element(results)),
-    test:assert-equal(2, $actual/@page-length/xs:int(.)),
-    test:assert-equal(2, fn:count($actual/result)),
+    test:assert-equal(1, $actual/@page-length/xs:int(.)),
+    test:assert-equal(1, fn:count($actual/result)),
     test:assert-equal(1, $actual/@start/xs:int(.)),
-    test:assert-equal(5, $actual/@total/xs:int(.)),
+    test:assert-equal(2, $actual/@total/xs:int(.)),
     test:assert-not-exists($actual/result/@total),
     for $r at $i in $actual/result
     order by $r/@index/xs:int(.) ascending
@@ -134,18 +134,18 @@ return (
   ),
 
   (: test last page :)
-  let $actual := matcher:find-document-matches-by-options($doc, $options, 5, 2, fn:true(), cts:true-query())
+  let $actual := matcher:find-document-matches-by-options($doc, $options, 2, 2, fn:true(), cts:true-query())
   return (
     test:assert-true($actual instance of element(results)),
     test:assert-equal(2, $actual/@page-length/xs:int(.)),
     test:assert-equal(1, fn:count($actual/result)),
-    test:assert-equal(5, $actual/@start/xs:int(.)),
-    test:assert-equal(5, $actual/@total/xs:int(.)),
+    test:assert-equal(2, $actual/@start/xs:int(.)),
+    test:assert-equal(2, $actual/@total/xs:int(.)),
     test:assert-not-exists($actual/result/@total),
     for $r at $i in $actual/result
     order by $r/@index/xs:int(.) ascending
     return
-      test:assert-equal($i + 4, $r/@index/xs:int(.))
+      test:assert-equal($i + 1, $r/@index/xs:int(.))
   ),
 
   (: test no results :)

--- a/src/test/ml-modules/root/test/suites/matching/match-with-posted-options.sjs
+++ b/src/test/ml-modules/root/test/suites/matching/match-with-posted-options.sjs
@@ -11,10 +11,10 @@ let postWithOptionsResponse = test.httpPost(`v1/resources/sm-match?rs:uri=${xdmp
 let actual = fn.head(fn.tail(postWithOptionsResponse)).toObject();
 [].concat(
   test.assertEqual("200", fn.string(fn.head(postWithOptionsResponse).xpath('//*:code'))),
-  test.assertEqual("5", actual.results.total.toString()),
+  test.assertEqual("2", actual.results.total.toString()),
   test.assertEqual("6", actual.results['page-length'].toString()),
   test.assertEqual("1", actual.results.start.toString()),
-  test.assertEqual(5, actual.results.result.length)
+  test.assertEqual(2, actual.results.result.length)
 )
 // Test includesMatches option
 actual.results.result.forEach((result) => {

--- a/src/test/ml-modules/root/test/suites/matching/results-to-json.sjs
+++ b/src/test/ml-modules/root/test/suites/matching/results-to-json.sjs
@@ -14,8 +14,8 @@ let actual = matcher.resultsToJson(actualXML);
 
 [
   // the top-level properties are text nodes, although the values are numeric
-  test.assertEqual("5", actual.results.total.toString()),
+  test.assertEqual("2", actual.results.total.toString()),
   test.assertEqual("6", actual.results['page-length'].toString()),
   test.assertEqual("1", actual.results.start.toString()),
-  test.assertEqual(5, actual.results.result.length)
+  test.assertEqual(2, actual.results.result.length)
 ]

--- a/src/test/ml-modules/root/test/suites/matching/test-data/doc1.json
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/doc1.json
@@ -12,7 +12,10 @@
           "user": "admin",
           "dateTime": "2018-04-26T16:40:02.1386Z"
         }
-      ]
+      ],
+      "meta": {
+        "PersonSurName": "JONES"
+      }
     },
     "triples": [],
     "instance": {

--- a/src/test/ml-modules/root/test/suites/matching/test-data/doc1.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/doc1.xml
@@ -10,6 +10,9 @@
         <smart-mastering:dateTime>2018-04-26T16:40:02.1386Z</smart-mastering:dateTime>
       </smart-mastering:source>
     </smart-mastering:sources>
+    <meta xmlns="">
+      <PersonSurName>JONES</PersonSurName>
+    </meta>
   </headers>
   <triples/>
   <instance>


### PR DESCRIPTION
Adjust the queries to be restricted to inside the instance by wrapping the query in a scoped query to avoid additional matches outside the instance that may affect the score.

Note that this required some of the tests to be adjusted because JSON documents will not show up in the results of an XML document and vice versa.