### PR TITLE
MDM-542 Preserve element namespaces in match queries

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/matcher-impl.xqy
@@ -437,6 +437,7 @@ declare function match-impl:strip-query-weights($queries)
         }
       case element() return
         element { fn:node-name($query) } {
+          $query/namespace::*,
           $query/@*,
           match-impl:strip-query-weights($query/node())
         }

--- a/src/test/ml-modules/root/test/suites/matching/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/lib/lib.xqy
@@ -11,6 +11,10 @@ declare variable $URI6 := "/source/3/doc3.json";
 declare variable $URI7 := "/source/3/doc4.xml";
 declare variable $URI8 := "/source/3/no-match.xml";
 
+declare variable $NAMESPACED-URI1 := "/source/1/namespaced-doc1.xml";
+declare variable $NAMESPACED-URI2 := "/source/2/namespaced-doc2.xml";
+declare variable $NAMESPACED-URI3 := "/source/3/namespaced-doc3.xml";
+declare variable $NAMESPACED-URI7 := "/source/3/namespaced-doc4.xml";
 
 declare variable $TEST-DATA :=
   map:new((
@@ -18,6 +22,10 @@ declare variable $TEST-DATA :=
     map:entry($URI2, "doc2.xml"),
     map:entry($URI3, "doc3.xml"),
     map:entry($URI7, "doc4.xml"),
+    map:entry($NAMESPACED-URI1, "namespaced-doc1.xml"),
+    map:entry($NAMESPACED-URI2, "namespaced-doc2.xml"),
+    map:entry($NAMESPACED-URI3, "namespaced-doc3.xml"),
+    map:entry($NAMESPACED-URI7, "namespaced-doc4.xml"),
     map:entry($URI4, "doc1.json"),
     map:entry($URI5, "doc2.json"),
     map:entry($URI6, "doc3.json"),
@@ -28,3 +36,4 @@ declare variable $MATCH-OPTIONS-NAME := "match-test";
 declare variable $SCORE-OPTIONS-NAME := "score-options";
 declare variable $SCORE-OPTIONS-NAME2 := "score-options2";
 
+declare variable $NAMESPACED-MATCH-OPTIONS-NAME := "namespaced-match-test";

--- a/src/test/ml-modules/root/test/suites/matching/namespaced-match-response.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/namespaced-match-response.xqy
@@ -1,0 +1,153 @@
+xquery version "1.0-ml";
+
+import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
+  at "/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace constants = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare option xdmp:mapping "false";
+
+(:
+ : Example result (from first test, with just 2 results).
+ : Note: matching is expected to run with either XML or JSON documents, not a
+ : mix. This test's data has a mix so that we can play with both. In this
+ : example response, no <match> elements under the JSON documents is due to the
+ : format mismatch.
+
+  <results total="5" page-length="6" start="1">
+    <boost-query>
+      <cts:or-query xmlns:cts="http://marklogic.com/cts">
+        <cts:element-value-query weight="50">
+          <cts:element>IdentificationID</cts:element>
+          <cts:text xml:lang="en">393225353</cts:text>
+          <cts:option>case-insensitive</cts:option>
+        </cts:element-value-query>
+        <cts:element-value-query weight="8">
+          <cts:element>PersonSurName</cts:element>
+          <cts:text xml:lang="en">JONES</cts:text>
+          <cts:option>case-insensitive</cts:option>
+        </cts:element-value-query>
+        <cts:element-value-query weight="12">
+          <cts:element>PersonGivenName</cts:element>
+          <cts:text xml:lang="en">LINDSEY</cts:text>
+          <cts:option>case-insensitive</cts:option>
+        </cts:element-value-query>
+        <cts:element-value-query weight="5">
+          <cts:element>AddressPrivateMailboxText</cts:element>
+          <cts:text xml:lang="en">45</cts:text>
+          <cts:option>case-insensitive</cts:option>
+        </cts:element-value-query>
+        <cts:element-value-query>
+          <cts:element>LocationState</cts:element>
+          <cts:text xml:lang="en">PA</cts:text>
+          <cts:option>case-insensitive</cts:option>
+        </cts:element-value-query>
+        <cts:element-value-query weight="3">
+          <cts:element>LocationPostalCode</cts:element>
+          <cts:text xml:lang="en">18505</cts:text>
+          <cts:option>case-insensitive</cts:option>
+        </cts:element-value-query>
+      </cts:or-query>
+    </boost-query>
+    <match-query>
+      <cts:and-query xmlns:cts="http://marklogic.com/cts">
+        <cts:collection-query>
+          <cts:uri>mdm-content</cts:uri>
+        </cts:collection-query>
+        <cts:not-query>
+          <cts:document-query>
+            <cts:uri>/source/2/namespaced-doc2.xml</cts:uri>
+          </cts:document-query>
+        </cts:not-query>
+        <cts:or-query>
+          <cts:element-value-query weight="0">
+            <cts:element>IdentificationID</cts:element>
+            <cts:text xml:lang="en">393225353</cts:text>
+            <cts:option>case-insensitive</cts:option>
+          </cts:element-value-query>
+        </cts:or-query>
+      </cts:and-query>
+    </match-query>
+    <result uri="/source/3/namespaced-doc3.xml" index="1" score="79" threshold="Definitive Match" action="merge">
+      <matches>
+        <match>fn:doc("/source/3/namespaced-doc3.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:PersonName/*:PersonNameType/*:PersonSurName/text()</match>
+        <match>fn:doc("/source/3/namespaced-doc3.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:PersonName/*:PersonNameType/*:PersonGivenName/text()</match>
+        <match>fn:doc("/source/3/namespaced-doc3.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:Address/*:AddressType/*:LocationState/text()</match>
+        <match>fn:doc("/source/3/namespaced-doc3.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:Address/*:AddressType/*:AddressPrivateMailboxText/text()</match>
+        <match>fn:doc("/source/3/namespaced-doc3.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:Address/*:AddressType/*:LocationPostalCode/text()</match>
+        <match>fn:doc("/source/3/namespaced-doc3.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:PersonSSNIdentification/*:PersonSSNIdentificationType/*:IdentificationID/text()</match>
+      </matches>
+    </result>
+    <result uri="/source/1/namespaced-doc1.xml" index="2" score="70" threshold="Likely Match" action="notify">
+      <matches>
+        <match>fn:doc("/source/1/namespaced-doc1.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:PersonName/*:PersonNameType/*:PersonSurName/text()</match>
+        <match>fn:doc("/source/1/namespaced-doc1.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:PersonName/*:PersonNameType/*:PersonGivenName/text()</match>
+        <match>fn:doc("/source/1/namespaced-doc1.xml")/es:envelope/es:instance/*:MDM/*:Person/*:PersonType/*:PersonSSNIdentification/*:PersonSSNIdentificationType/*:IdentificationID/text()</match>
+      </matches>
+    </result>
+  </results>
+ :)
+
+let $doc := fn:doc($lib:NAMESPACED-URI2)
+let $options := matcher:get-options-as-xml($lib:NAMESPACED-MATCH-OPTIONS-NAME)
+return (
+  (: test page length gt # of results :)
+  let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 6, fn:true(), cts:true-query())
+  return (
+    test:assert-true($actual instance of element(results)),
+    test:assert-equal(6, $actual/@page-length/xs:int(.)),
+    test:assert-equal(2, fn:count($actual/result)),
+    test:assert-equal(1, $actual/@start/xs:int(.)),
+    test:assert-equal(2, $actual/@total/xs:int(.)),
+    test:assert-not-exists($actual/result/@total),
+    for $r at $i in $actual/result
+    order by $r/@index/xs:int(.) ascending
+    return
+      test:assert-equal($i, $r/@index/xs:int(.))
+  ),
+
+  (: test page length < # of results :)
+  let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 1, fn:true(), cts:true-query())
+  return (
+    test:assert-true($actual instance of element(results)),
+    test:assert-equal(1, $actual/@page-length/xs:int(.)),
+    test:assert-equal(1, fn:count($actual/result)),
+    test:assert-equal(1, $actual/@start/xs:int(.)),
+    test:assert-equal(2, $actual/@total/xs:int(.)),
+    test:assert-not-exists($actual/result/@total),
+    for $r at $i in $actual/result
+    order by $r/@index/xs:int(.) ascending
+    return
+      test:assert-equal($i, $r/@index/xs:int(.))
+  ),
+
+  (: test last page :)
+  let $actual := matcher:find-document-matches-by-options($doc, $options, 2, 2, fn:true(), cts:true-query())
+  return (
+    test:assert-true($actual instance of element(results)),
+    test:assert-equal(2, $actual/@page-length/xs:int(.)),
+    test:assert-equal(1, fn:count($actual/result)),
+    test:assert-equal(2, $actual/@start/xs:int(.)),
+    test:assert-equal(2, $actual/@total/xs:int(.)),
+    test:assert-not-exists($actual/result/@total),
+    for $r at $i in $actual/result
+    order by $r/@index/xs:int(.) ascending
+    return
+      test:assert-equal($i + 1, $r/@index/xs:int(.))
+  ),
+
+  (: test no results :)
+  let $doc := fn:doc($lib:URI7)
+  let $actual := matcher:find-document-matches-by-options($doc, $options, 5, 2, fn:true(), cts:true-query())
+  return (
+    test:assert-true($actual instance of element(results)),
+    test:assert-equal(2, $actual/@page-length/xs:int(.)),
+    test:assert-equal(0, fn:count($actual/result)),
+    test:assert-equal(5, $actual/@start/xs:int(.)),
+    test:assert-equal(0, $actual/@total/xs:int(.)),
+    test:assert-not-exists($actual/result/@total)
+  )
+)

--- a/src/test/ml-modules/root/test/suites/matching/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/suite-setup.xqy
@@ -9,6 +9,7 @@ import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test
 
 declare option xdmp:mapping "false";
 
+matcher:save-options($lib:NAMESPACED-MATCH-OPTIONS-NAME, test:get-test-file("namespaced-match-options.xml")),
 matcher:save-options($lib:MATCH-OPTIONS-NAME, test:get-test-file("match-options.xml")),
 matcher:save-options($lib:SCORE-OPTIONS-NAME, test:get-test-file("scoring-options.xml")),
 matcher:save-options($lib:SCORE-OPTIONS-NAME2, test:get-test-file("scoring-options2.xml")),

--- a/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc1.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc1.xml
@@ -1,0 +1,59 @@
+<envelope xmlns="http://marklogic.com/entity-services">
+  <headers>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">bbc806e4-ff00-4585-9d46-877edbc3248e</smart-mastering:id>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">66cbe731-7b56-4c91-9257-18a973008277</smart-mastering:id>
+    <smart-mastering:sources xmlns:smart-mastering="http://marklogic.com/smart-mastering">
+      <smart-mastering:source>
+        <smart-mastering:name>SOURCE1</smart-mastering:name>
+        <smart-mastering:import-id>mdm-import-8cf89514-fb1d-45f1-b95f-8b69f3126f04</smart-mastering:import-id>
+        <smart-mastering:user>admin</smart-mastering:user>
+        <smart-mastering:dateTime>2018-04-26T16:40:02.1386Z</smart-mastering:dateTime>
+      </smart-mastering:source>
+    </smart-mastering:sources>
+    <meta xmlns="document:namespace">
+      <PersonSurName>JONES</PersonSurName>
+    </meta>
+  </headers>
+  <triples/>
+  <instance>
+    <MDM xmlns="document:namespace">
+      <Person>
+        <PersonType>
+          <PersonName>
+            <PersonNameType>
+              <PersonSurName>JONES</PersonSurName>
+              <PersonGivenName>LINDSEY</PersonGivenName>
+            </PersonNameType>
+          </PersonName>
+          <Address>
+            <AddressType>
+              <LocationState>OH</LocationState>
+              <AddressPrivateMailboxText>72980</AddressPrivateMailboxText>
+              <AddressSecondaryUnitText>LONDONDERRY</AddressSecondaryUnitText>
+              <LocationPostalCode>45505</LocationPostalCode>
+              <LocationCityName>SPRINGFIELD</LocationCityName>
+            </AddressType>
+          </Address>
+          <IncidentCategoryCodeDate/>
+          <id>6986792174</id>
+          <PersonBirthDate>19801001</PersonBirthDate>
+          <PersonSex>F</PersonSex>
+          <CaseAmount>1287.9</CaseAmount>
+          <CustomThing>1</CustomThing>
+          <PersonSSNIdentification>
+            <PersonSSNIdentificationType>
+              <IdentificationID>393225353</IdentificationID>
+            </PersonSSNIdentificationType>
+          </PersonSSNIdentification>
+          <Revenues>
+            <RevenuesType>
+              <Revenue/>
+            </RevenuesType>
+          </Revenues>
+          <CaseStartDate>20110406</CaseStartDate>
+        </PersonType>
+      </Person>
+    </MDM>
+  </instance>
+  <attachments/>
+</envelope>

--- a/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc2.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc2.xml
@@ -1,0 +1,55 @@
+<envelope xmlns="http://marklogic.com/entity-services">
+  <headers>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">87c2f600-7488-429a-862c-0b2a5f6c6e1e</smart-mastering:id>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">f57e1093-4c68-46d7-910c-150825ab2edc</smart-mastering:id>
+    <smart-mastering:sources xmlns:smart-mastering="http://marklogic.com/smart-mastering">
+      <smart-mastering:source>
+        <smart-mastering:name>SOURCE2</smart-mastering:name>
+        <smart-mastering:import-id>mdm-import-b96735af-f7c3-4f95-9ea1-f884bc395e0f</smart-mastering:import-id>
+        <smart-mastering:user>admin</smart-mastering:user>
+        <smart-mastering:dateTime>2018-04-26T16:40:16.760311Z</smart-mastering:dateTime>
+      </smart-mastering:source>
+    </smart-mastering:sources>
+  </headers>
+  <triples/>
+  <instance>
+    <MDM xmlns="document:namespace">
+      <Person>
+        <PersonType>
+          <PersonName>
+            <PersonNameType>
+              <PersonSurName>JONES</PersonSurName>
+              <PersonGivenName>LINDSEY</PersonGivenName>
+            </PersonNameType>
+          </PersonName>
+          <Address>
+            <AddressType>
+              <LocationState>PA</LocationState>
+              <AddressPrivateMailboxText>45</AddressPrivateMailboxText>
+              <AddressSecondaryUnitText>JANA</AddressSecondaryUnitText>
+              <LocationPostalCode>18505</LocationPostalCode>
+              <LocationCityName>SCRANTON</LocationCityName>
+            </AddressType>
+          </Address>
+          <IncidentCategoryCodeDate/>
+          <id>6270654339</id>
+          <PersonBirthDate>19801001</PersonBirthDate>
+          <CaseAmount>1287.9</CaseAmount>
+          <CustomThing>2</CustomThing>
+          <PersonSSNIdentification>
+            <PersonSSNIdentificationType>
+              <IdentificationID>393225353</IdentificationID>
+            </PersonSSNIdentificationType>
+          </PersonSSNIdentification>
+          <Revenues>
+            <RevenuesType>
+              <Revenue>4332</Revenue>
+            </RevenuesType>
+          </Revenues>
+          <CaseStartDate>20110406</CaseStartDate>
+        </PersonType>
+      </Person>
+    </MDM>
+  </instance>
+  <attachments/>
+</envelope>

--- a/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc3.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc3.xml
@@ -1,0 +1,55 @@
+<envelope xmlns="http://marklogic.com/entity-services">
+  <headers>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">87c2f600-7488-429a-862c-0b2a5f6c6e1e</smart-mastering:id>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">f57e1093-4c68-46d7-910c-150825ab2edc</smart-mastering:id>
+    <smart-mastering:sources xmlns:smart-mastering="http://marklogic.com/smart-mastering">
+      <smart-mastering:source>
+        <smart-mastering:name>SOURCE2</smart-mastering:name>
+        <smart-mastering:import-id>mdm-import-b96735af-f7c3-4f95-9ea1-f884bc395e0f</smart-mastering:import-id>
+        <smart-mastering:user>admin</smart-mastering:user>
+        <smart-mastering:dateTime>2018-04-26T16:40:16.760311Z</smart-mastering:dateTime>
+      </smart-mastering:source>
+    </smart-mastering:sources>
+  </headers>
+  <triples/>
+  <instance>
+    <MDM xmlns="document:namespace">
+      <Person>
+        <PersonType>
+          <PersonName>
+            <PersonNameType>
+              <PersonSurName>JONES</PersonSurName>
+              <PersonGivenName>LINDSEY</PersonGivenName>
+            </PersonNameType>
+          </PersonName>
+          <Address>
+            <AddressType>
+              <LocationState>PA</LocationState>
+              <AddressPrivateMailboxText>45</AddressPrivateMailboxText>
+              <AddressSecondaryUnitText>JANA</AddressSecondaryUnitText>
+              <LocationPostalCode>18505</LocationPostalCode>
+              <LocationCityName>SCRANTON</LocationCityName>
+            </AddressType>
+          </Address>
+          <IncidentCategoryCodeDate/>
+          <id>6270654339</id>
+          <PersonBirthDate>19801001</PersonBirthDate>
+          <CaseAmount>1287.9</CaseAmount>
+          <CustomThing>2</CustomThing>
+          <PersonSSNIdentification>
+            <PersonSSNIdentificationType>
+              <IdentificationID>393225353</IdentificationID>
+            </PersonSSNIdentificationType>
+          </PersonSSNIdentification>
+          <Revenues>
+            <RevenuesType>
+              <Revenue>4332</Revenue>
+            </RevenuesType>
+          </Revenues>
+          <CaseStartDate>20110406</CaseStartDate>
+        </PersonType>
+      </Person>
+    </MDM>
+  </instance>
+  <attachments/>
+</envelope>

--- a/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc4.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-doc4.xml
@@ -1,0 +1,32 @@
+<envelope xmlns="http://marklogic.com/entity-services">
+  <headers>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">87c2f600-7488-429a-862c-0b2a5f6c6e1e</smart-mastering:id>
+    <smart-mastering:id xmlns:smart-mastering="http://marklogic.com/smart-mastering">f57e1093-4c68-46d7-910c-150825ab2edc</smart-mastering:id>
+    <smart-mastering:sources xmlns:smart-mastering="http://marklogic.com/smart-mastering">
+      <smart-mastering:source>
+        <smart-mastering:name>SOURCE4</smart-mastering:name>
+        <smart-mastering:import-id>mdm-import-b96735af-f7c3-4f95-9ea1-f344bc395e0f</smart-mastering:import-id>
+        <smart-mastering:user>admin</smart-mastering:user>
+        <smart-mastering:dateTime>2018-04-26T16:40:16.760311Z</smart-mastering:dateTime>
+      </smart-mastering:source>
+    </smart-mastering:sources>
+  </headers>
+  <triples/>
+  <instance>
+    <MDM xmlns="document:namespace">
+      <Person>
+        <PersonType>
+          <Address>
+            <AddressType>
+              <LocationState>PA</LocationState>
+            </AddressType>
+            <AddressType>
+              <LocationState>PA</LocationState>
+            </AddressType>
+          </Address>
+        </PersonType>
+      </Person>
+    </MDM>
+  </instance>
+  <attachments/>
+</envelope>

--- a/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-match-options.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/namespaced-match-options.xml
@@ -1,0 +1,48 @@
+<options xmlns="http://marklogic.com/smart-mastering/matcher">
+  <property-defs>
+    <property namespace="document:namespace" localname="IdentificationID" name="ssn"/>
+    <property namespace="document:namespace" localname="PersonGivenName" name="first-name"/>
+    <property namespace="document:namespace" localname="PersonSurName" name="last-name"/>
+    <property namespace="document:namespace" localname="AddressPrivateMailboxText" name="addr1"/>
+    <property namespace="document:namespace" localname="LocationCity" name="city"/>
+    <property namespace="document:namespace" localname="LocationState" name="state"/>
+    <property namespace="document:namespace" localname="LocationPostalCode" name="zip"/>
+  </property-defs>
+  <algorithms>
+    <algorithm name="std-reduce" function="standard-reduction"/>
+    <algorithm name="dbl-metaphone" function="double-metaphone"/>
+  </algorithms>
+  <scoring>
+    <add property-name="ssn" weight="50"/>
+    <add property-name="last-name" weight="8"/>
+    <add property-name="first-name" weight="12"/>
+    <add property-name="addr1" weight="5"/>
+    <add property-name="city" weight="3"/>
+    <add property-name="state" weight="1"/>
+    <add property-name="zip" weight="3"/>
+    <expand property-name="first-name" algorithm-ref="dbl-metaphone" weight="6">
+      <dictionary>name-dictionary.xml</dictionary>
+      <distance-threshold>10</distance-threshold>
+    </expand>
+    <expand property-name="last-name" algorithm-ref="dbl-metaphone" weight="8">
+      <dictionary>name-dictionary.xml</dictionary>
+      <!--defaults to 100 distance -->
+    </expand>
+    <reduce algorithm-ref="std-reduce" weight="4">
+      <all-match>
+        <property>last-name</property>
+        <property>addr1</property>
+      </all-match>
+    </reduce>
+  </scoring>
+  <thresholds>
+    <threshold above="30" label="Possible Match"/>
+    <threshold above="50" label="Likely Match" action="notify"/>
+    <threshold above="75" label="Definitive Match" action="merge"/>
+    <!-- below 25 will be NOT-A-MATCH or no category -->
+  </thresholds>
+  <tuning>
+    <max-scan>200</max-scan>  <!-- never look at more than 200 -->
+    <initial-scan>20</initial-scan>
+  </tuning>
+</options>


### PR DESCRIPTION
When we serialize the cts queries as XML to calculate minimum queries required for a match, we were losing the namespace on the cts:element element. This will now preserve the namespace.

Fixes issue #166  