### PR TITLE
MDM-544 Added ability to set a default merge and define merge strategies

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -1866,7 +1866,7 @@ declare function merge-impl:options-to-json($options-xml as element(merging:opti
                       "timestamp": object-node {
                         "path":
                           let $path :=
-                            fn:head($options-xml/merging:algorithms/merging:std-algorithm/merging:timestamp/@path/fn:string())
+                            fn:head($options-xml/merging:algorithms/merging:std-algorithm/merging:timestamp/@path/fn:string()[. ne ''])
                           return
                             if (fn:exists($path)) then $path
                             else null-node {}

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -1374,6 +1374,14 @@ declare function merge-impl:get-merge-spec(
     )
 };
 
+(:
+ : Take in a merge spec and if doesn't exist search for a default merge from the options.
+ : Also, look for any referenced merge strategies and pull in the properties from the strategy.
+ :
+ : @param $options element(merging:options) the entire merge options
+ : @param $merge-details element(merging:merge) the element describing how a merge should occur
+ : @return $merge-details element(merging:merge) with details filled in from referenced strategy
+ :)
 declare function merge-impl:expand-merge-spec(
   $options as element(merging:options),
   $merge-details as element(merging:merge)?

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -1348,7 +1348,10 @@ declare function merge-impl:get-path-merge-spec(
 {
   let $property-name := $options/merging:property-defs/merging:property[@path = $path]/@name
   return
-    $options/merging:merging/merging:merge[@property-name = $property-name]
+    merge-impl:expand-merge-spec(
+      $options,
+      $options/merging:merging/merging:merge[@property-name = $property-name]
+    )
 };
 
 (:
@@ -1365,7 +1368,36 @@ declare function merge-impl:get-merge-spec(
     $options/merging:property-defs
       /merging:property[@namespace = $property-namespace and @localname = $property-local-name]/@name
   return
-    $options/merging:merging/merging:merge[@property-name = $property-name]
+    merge-impl:expand-merge-spec(
+      $options,
+      $options/merging:merging/merging:merge[@property-name = $property-name]
+    )
+};
+
+declare function merge-impl:expand-merge-spec(
+  $options as element(merging:options),
+  $merge-details as element(merging:merge)?
+) as element(merging:merge)?
+{
+
+  let $merge-details :=
+    if (fn:exists($merge-details)) then
+      $merge-details
+    else
+      $options/merging:merging/merging:merge[@default][@default cast as xs:boolean]
+  let $strategy-name := $merge-details/@strategy
+  return
+    if (fn:exists($strategy-name)) then
+      let $strategy := $options/merging:merging/merging:merge-strategy[@name eq $strategy-name]
+      return
+        element merging:merge {
+          for $node-name in fn:distinct-values(($strategy/@*, $merge-details/@*) ! fn:node-name())
+          return fn:head(($merge-details/@*[fn:node-name() eq $node-name],$strategy/@*[fn:node-name() eq $node-name])),
+          for $node-name in fn:distinct-values(($strategy/*, $merge-details/*) ! fn:node-name())
+          return fn:head(($merge-details/*[fn:node-name() eq $node-name],$strategy/*[fn:node-name() eq $node-name]))
+        }
+    else
+      $merge-details
 };
 
 (:
@@ -1837,6 +1869,16 @@ declare function merge-impl:options-to-json($options-xml as element(merging:opti
               ))
             )
           else (),
+          if (fn:exists($options-xml/merging:merging/merging:merge-strategy)) then
+            map:entry(
+              "mergeStrategies",
+              array-node {
+                for $merge in $options-xml/merging:merging/merging:merge-strategy
+                return
+                  merge-impl:propertyspec-to-json($merge)
+              }
+            )
+          else (),
           if (fn:exists($options-xml/merging:merging/merging:merge)) then
             map:entry(
               "merging",
@@ -1938,12 +1980,19 @@ declare function merge-impl:options-from-json($options-json as object-node())
         let $config := json:config("custom")
           => map:with("camel-case", fn:true())
           => map:with("whitespace", "ignore")
-          => map:with("attribute-names", ("propertyName", "algorithmRef", "maxValues"))
-        for $merge in $options-json/*:options/*:merging
-        return
-          element merge {
-            json:transform-from-json($merge, $config)
-          }
+          => map:with("attribute-names", ("name", "weight", "strategy", "propertyName", "algorithmRef", "maxValues"))
+        return (
+          for $merge in $options-json/*:options/*:merging
+          return
+            element merge {
+              json:transform-from-json($merge, $config)
+            },
+          for $merge-strategy in $options-json/*:options/*:mergeStrategies
+          return
+            element merge-strategy {
+              json:transform-from-json($merge-strategy, $config)
+            }
+        )
       },
       let $triple-merge := $options-json/*:options/*:tripleMerge
       return
@@ -1971,12 +2020,12 @@ declare function merge-impl:_options-json-config()
 {
   let $config := json:config("custom")
   return (
-    map:put($config, "array-element-names", ("algorithm","threshold","scoring","property", "reduce", "add", "expand", "merging")),
+    map:put($config, "array-element-names", ("algorithm","threshold","scoring","property", "reduce", "add", "expand", "merging", "merge-strategy", "mergeStrategy")),
     map:put($config, "element-namespace", "http://marklogic.com/smart-mastering/merging"),
     map:put($config, "element-namespace-prefix", "merging"),
     map:put($config, "attribute-names",
       ("name","localname", "namespace", "function",
-        "at", "property-name", "propertyName", "weight", "above", "label","algorithm-ref", "algorithmRef")
+        "at", "property-name", "propertyName", "weight", "above", "label","algorithm-ref", "algorithmRef", "strategy", "default")
     ),
     map:put($config, "camel-case", fn:true()),
     map:put($config, "whitepsace", "ignore"),

--- a/src/test/ml-modules/root/test/suites/matching/test-data/match-options-with-defaults.xml
+++ b/src/test/ml-modules/root/test/suites/matching/test-data/match-options-with-defaults.xml
@@ -1,0 +1,48 @@
+<options xmlns="http://marklogic.com/smart-mastering/matcher">
+  <property-defs>
+    <property namespace="" localname="IdentificationID" name="ssn"/>
+    <property namespace="" localname="PersonGivenName" name="first-name"/>
+    <property namespace="" localname="PersonSurName" name="last-name"/>
+    <property namespace="" localname="AddressPrivateMailboxText" name="addr1"/>
+    <property namespace="" localname="LocationCity" name="city"/>
+    <property namespace="" localname="LocationState" name="state"/>
+    <property namespace="" localname="LocationPostalCode" name="zip"/>
+  </property-defs>
+  <algorithms>
+    <algorithm name="std-reduce" function="standard-reduction"/>
+    <algorithm name="dbl-metaphone" function="double-metaphone"/>
+  </algorithms>
+  <scoring>
+    <add property-name="ssn" weight="50"/>
+    <add property-name="last-name" weight="8"/>
+    <add property-name="first-name" weight="12"/>
+    <add property-name="addr1" weight="5"/>
+    <add property-name="city" weight="3"/>
+    <add property-name="state" weight="1"/>
+    <add property-name="zip" weight="3"/>
+    <expand property-name="first-name" algorithm-ref="dbl-metaphone" weight="6">
+      <dictionary>name-dictionary.xml</dictionary>
+      <distance-threshold>10</distance-threshold>
+    </expand>
+    <expand property-name="last-name" algorithm-ref="dbl-metaphone" weight="8">
+      <dictionary>name-dictionary.xml</dictionary>
+      <!--defaults to 100 distance -->
+    </expand>
+    <reduce algorithm-ref="std-reduce" weight="4">
+      <all-match>
+        <property>last-name</property>
+        <property>addr1</property>
+      </all-match>
+    </reduce>
+  </scoring>
+  <thresholds>
+    <threshold above="30" label="Possible Match"/>
+    <threshold above="50" label="Likely Match" action="notify"/>
+    <threshold above="75" label="Definitive Match" action="merge"/>
+    <!-- below 25 will be NOT-A-MATCH or no category -->
+  </thresholds>
+  <tuning>
+    <max-scan>200</max-scan>  <!-- never look at more than 200 -->
+    <initial-scan>20</initial-scan>
+  </tuning>
+</options>

--- a/src/test/ml-modules/root/test/suites/merging-json/json-options-round-trip.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/json-options-round-trip.xqy
@@ -11,9 +11,14 @@ import module namespace merging = "http://marklogic.com/smart-mastering/merging"
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 
 declare variable $options := test:get-test-file("merge-options.json");
+declare variable $strategy-options := test:get-test-file("merge-options-with-strategies.json");
 
 (: Save JSON options, which will get them written as XML :)
-merging:save-options("json-options", $options)
+merging:save-options("json-options", $options),
+
+
+(: Save JSON options, which will get them written as XML :)
+merging:save-options("json-options-with-strategy", $strategy-options)
 
 ;
 
@@ -27,6 +32,7 @@ import module namespace merging = "http://marklogic.com/smart-mastering/merging"
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
 
 declare variable $options := test:get-test-file("merge-options.json")/node();
+declare variable $strategy-options := test:get-test-file("merge-options-with-strategies.json")/node();
 
 (: Retrieve options, requesting JSON format, so they will be converted back to
  : JSON.
@@ -36,4 +42,11 @@ return test:assert-equal-json($options, $actual),
 
 let $expected := test:get-test-file("merge-options.json")/node()
 let $actual := merging:get-options($lib:OPTIONS-NAME-COMPLETE, $const:FORMAT-JSON)
-return test:assert-equal-json($expected, $actual)
+return test:assert-equal-json($expected, $actual),
+
+(: For some reason, the below test needed to convert the JSON to string to determine
+ : that they are equal. See https://github.com/marklogic-community/marklogic-unit-test/issues/44
+ :)
+let $expected := test:get-test-file("merge-options-with-strategies.json")/node()
+let $actual := merging:get-options($lib:OPTIONS-NAME-STRATEGIES, $const:FORMAT-JSON)
+return test:assert-equal(xdmp:to-json-string($expected), xdmp:to-json-string($actual))

--- a/src/test/ml-modules/root/test/suites/merging-json/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/lib/lib.xqy
@@ -20,6 +20,7 @@ declare variable $NESTED-DATA :=
   ));
 
 declare variable $OPTIONS-NAME := "test-options";
+declare variable $OPTIONS-NAME-STRATEGIES := "test-options-with-strategies";
 declare variable $OPTIONS-NAME-COMPLETE := "test-options-stock";
 declare variable $OPTIONS-NAME-CUST-XQY := "cust-xqy-test-options";
 declare variable $OPTIONS-NAME-CUST-SJS := "cust-sjs-test-options";

--- a/src/test/ml-modules/root/test/suites/merging-json/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-json/suite-setup.xqy
@@ -9,6 +9,7 @@ import module namespace lib = "http://marklogic.com/smart-mastering/test" at "li
 declare option xdmp:mapping "false";
 
 merging:save-options($lib:OPTIONS-NAME, test:get-test-file("merge-options.xml")),
+merging:save-options($lib:OPTIONS-NAME-STRATEGIES, test:get-test-file("merge-options-with-strategies.xml")),
 merging:save-options($lib:OPTIONS-NAME-COMPLETE, test:get-test-file("merge-options-complete.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-XQY, test:get-test-file("custom-xqy-merge-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-SJS, test:get-test-file("custom-sjs-merge-options.xml")),

--- a/src/test/ml-modules/root/test/suites/merging-json/test-data/merge-options-with-strategies.json
+++ b/src/test/ml-modules/root/test/suites/merging-json/test-data/merge-options-with-strategies.json
@@ -1,0 +1,71 @@
+{
+    "options":
+    {
+        "matchOptions": "basic",
+        "merging": [
+        {
+            "propertyName": "ssn",
+            "algorithmRef": "user-defined",
+            "sourceRef":
+            {
+                "documentUri": "docA"
+            }
+        },
+        {
+            "propertyName": "name",
+            "maxValues": "1",
+            "doubleMetaphone":
+            {
+                "distanceThreshold": "50"
+            },
+            "synonymsSupport": "true",
+            "thesaurus": "/mdm/config/thesauri/first-name-synonyms.xml",
+            "length":
+            {
+                "weight": "8"
+            }
+        },
+        {
+            "default": "true",
+            "strategy": "default-standard"
+        }],
+        "propertyDefs":
+        {
+            "properties": [
+            {
+                "namespace": "",
+                "localname": "IdentificationID",
+                "name": "ssn"
+            },
+            {
+                "namespace": "",
+                "localname": "PersonName",
+                "name": "name"
+            },
+            {
+                "namespace": "",
+                "localname": "Address",
+                "name": "address"
+            }]
+        },
+        "mergeStrategies": [
+        {
+            "name": "default-standard",
+            "algorithmRef": "standard",
+            "maxValues": "1",
+            "sourceWeights":
+            {
+                "source":
+                {
+                    "name": "SOURCE1",
+                    "weight": "10"
+                }
+            }
+        }],
+        "algorithms":
+        {
+            "stdAlgorithm":{"namespaces":{}, "timestamp":{"path": null}},
+            "custom": []
+        }
+    }
+}

--- a/src/test/ml-modules/root/test/suites/merging-json/test-data/merge-options-with-strategies.xml
+++ b/src/test/ml-modules/root/test/suites/merging-json/test-data/merge-options-with-strategies.xml
@@ -1,0 +1,32 @@
+<options xmlns="http://marklogic.com/smart-mastering/merging">
+  <match-options>basic</match-options>
+  <property-defs>
+    <property namespace="" localname="IdentificationID" name="ssn"/>
+    <property namespace="" localname="PersonName" name="name"/>
+    <property namespace="" localname="Address" name="address"/>
+  </property-defs>
+  <algorithms>
+    <!-- config for standard algorithm -->
+    <std-algorithm>
+    </std-algorithm>
+  </algorithms>
+  <merging>
+    <merge-strategy name="default-standard" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE1" weight="10"></source>
+      </source-weights>
+    </merge-strategy>
+    <merge property-name="ssn" algorithm-ref="user-defined">
+      <source-ref document-uri="docA" />
+    </merge>
+    <merge property-name="name"  max-values="1">
+      <double-metaphone>
+        <distance-threshold>50</distance-threshold>
+      </double-metaphone>
+      <synonyms-support>true</synonyms-support>
+      <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
+      <length weight="8" />
+    </merge>
+    <merge default="true" strategy="default-standard"></merge>
+  </merging>
+</options>

--- a/src/test/ml-modules/root/test/suites/merging-xml/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/lib/lib.xqy
@@ -31,6 +31,8 @@ declare variable $OPTIONS-NAME-CUST-SJS := "cust-sjs-test-options";
 declare variable $OPTIONS-NAME-CUST-TRIPS-XQY := "cust-trips-xqy-test-options";
 declare variable $OPTIONS-NAME-CUST-TRIPS-SJS := "cust-trips-sjs-test-options";
 declare variable $OPTIONS-NAME-PATH := "path-test-options";
+declare variable $OPTIONS-NAME-WITH-DEFAULT-1 := "default-test-options-1";
+declare variable $OPTIONS-NAME-WITH-DEFAULT-2 := "default-test-options-2";
 
 declare variable $OPTIONS-NAME-CUST-ACTION-XQY-MATCH := "custom-xqy-action-match-options";
 declare variable $OPTIONS-NAME-CUST-ACTION-XQY-MERGE := "custom-xqy-action-merge-options";

--- a/src/test/ml-modules/root/test/suites/merging-xml/sm-merge-strategy.sjs
+++ b/src/test/ml-modules/root/test/suites/merging-xml/sm-merge-strategy.sjs
@@ -1,0 +1,38 @@
+const test = require('/test/test-helper.xqy');
+const lib = require('/test/suites/merging-xml/lib/lib.xqy');
+
+/**
+ * Purpose of test: Ensure our error messages are checking for required parameters.
+ *
+ */
+
+let httpOptions = {
+  "credentialId": xs.unsignedLong(fn.string(test.DEFAULT_HTTP_OPTIONS.xpath('.//*:credential-id'))),
+  "headers": { "Content-Type": "application/json", "Accept": "application/json"}
+};
+
+let uris = Object.keys(lib["TEST-DATA"]);
+let uriParam = fn.stringJoin(uris.map((uri) => `rs:uri=${xdmp.urlEncode(uri)}`), "&");
+let optParam = `rs:options=${lib["OPTIONS-NAME-WITH-DEFAULT-1"]}`;
+let previewParam = "rs:preview=true";
+
+let mergePreviewResp = test.httpPost("v1/resources/sm-merge?" + fn.stringJoin([uriParam,optParam,previewParam],"&"), httpOptions, null);
+let header = fn.head(mergePreviewResp);
+let body = fn.head(fn.tail(mergePreviewResp)).root;
+
+[
+  test.assertEqual("200", fn.string(header.xpath("/*:code"))),
+  test.assertSameValues(uris, body.xpath("/*:envelope/*:headers/*:merges/*:document-uri").toArray().map((val) => fn.string(val))),
+  test.assertSameValues("OH", body.xpath("/*:envelope/*:instance/MDM/Person/PersonType/Address/AddressType/LocationState").toArray().map((val) => fn.string(val)))
+];
+
+optParam = `rs:options=${lib["OPTIONS-NAME-WITH-DEFAULT-2"]}`;
+mergePreviewResp = test.httpPost("v1/resources/sm-merge?" + fn.stringJoin([uriParam,optParam,previewParam],"&"), httpOptions, null);
+header = fn.head(mergePreviewResp);
+body = fn.head(fn.tail(mergePreviewResp)).root;
+
+[
+  test.assertEqual("200", fn.string(header.xpath("/*:code"))),
+  test.assertSameValues(uris, body.xpath("/*:envelope/*:headers/*:merges/*:document-uri").toArray().map((val) => fn.string(val))),
+  test.assertSameValues("PA", body.xpath("/*:envelope/*:instance/MDM/Person/PersonType/Address/AddressType/LocationState").toArray().map((val) => fn.string(val)))
+];

--- a/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/merging-xml/suite-setup.xqy
@@ -17,6 +17,8 @@ merging:save-options($lib:OPTIONS-NAME-CUST-SJS, test:get-test-file("custom-sjs-
 merging:save-options($lib:OPTIONS-NAME-CUST-TRIPS-XQY, test:get-test-file("custom-xqy-triples-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-CUST-TRIPS-SJS, test:get-test-file("custom-sjs-triples-options.xml")),
 merging:save-options($lib:OPTIONS-NAME-PATH, test:get-test-file("path-merge-options.xml")),
+merging:save-options($lib:OPTIONS-NAME-WITH-DEFAULT-1, test:get-test-file("merge-options-with-default-1.xml")),
+merging:save-options($lib:OPTIONS-NAME-WITH-DEFAULT-2, test:get-test-file("merge-options-with-default-2.xml")),
 merging:save-options($lib:ONE-FIRST-OPTIONS, test:get-test-file("one-first-options.xml")),
 merging:save-options($lib:TWO-FIRST-OPTIONS, test:get-test-file("two-first-options.xml")),
 merging:save-options($lib:NESTED-OPTIONS, test:get-test-file("nested-merge-options.xml")),

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/merge-options-with-default-1.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/merge-options-with-default-1.xml
@@ -1,0 +1,34 @@
+<options xmlns="http://marklogic.com/smart-mastering/merging">
+  <match-options>basic</match-options>
+  <property-defs>
+    <property namespace="" localname="IdentificationID" name="ssn"/>
+    <property namespace="" localname="PersonName" name="name"/>
+    <property namespace="" localname="Address" name="address"/>
+  </property-defs>
+  <algorithms>
+    <!-- config for standard algorithm -->
+    <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
+      <timestamp path="/es:envelope/es:headers/sm:sources/sm:source/sm:one-first" />
+    </std-algorithm>
+  </algorithms>
+  <merging>
+    <merge-strategy name="default-standard" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE1" weight="10"></source>
+      </source-weights>
+    </merge-strategy>
+    <merge property-name="ssn">
+      <source-ref document-uri="docA" />
+    </merge>
+    <merge property-name="name"  max-values="1">
+      <double-metaphone>
+        <distance-threshold>50</distance-threshold>
+      </double-metaphone>
+      <synonyms-support>true</synonyms-support>
+      <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
+      <length weight="8" />
+    </merge>
+    <merge default="true" strategy="default-standard">
+    </merge>
+  </merging>
+</options>

--- a/src/test/ml-modules/root/test/suites/merging-xml/test-data/merge-options-with-default-2.xml
+++ b/src/test/ml-modules/root/test/suites/merging-xml/test-data/merge-options-with-default-2.xml
@@ -1,0 +1,34 @@
+<options xmlns="http://marklogic.com/smart-mastering/merging">
+  <match-options>basic</match-options>
+  <property-defs>
+    <property namespace="" localname="IdentificationID" name="ssn"/>
+    <property namespace="" localname="PersonName" name="name"/>
+    <property namespace="" localname="Address" name="address"/>
+  </property-defs>
+  <algorithms>
+    <!-- config for standard algorithm -->
+    <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
+      <timestamp path="/es:envelope/es:headers/sm:sources/sm:source/sm:one-first" />
+    </std-algorithm>
+  </algorithms>
+  <merging>
+    <merge-strategy name="default-standard" algorithm-ref="standard" max-values="1">
+      <source-weights>
+        <source name="SOURCE2" weight="10"></source>
+      </source-weights>
+    </merge-strategy>
+    <merge property-name="ssn">
+      <source-ref document-uri="docA" />
+    </merge>
+    <merge property-name="name"  max-values="1">
+      <double-metaphone>
+        <distance-threshold>50</distance-threshold>
+      </double-metaphone>
+      <synonyms-support>true</synonyms-support>
+      <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
+      <length weight="8" />
+    </merge>
+    <merge default="true" strategy="default-standard">
+    </merge>
+  </merging>
+</options>


### PR DESCRIPTION
Related to ticket #170

Allows for defining a default merge and referencing a merge strategy like shown below. Documentation updates will follow.

```xml
<options xmlns="http://marklogic.com/smart-mastering/merging">
  <match-options>basic</match-options>
  <property-defs>
    <property namespace="" localname="IdentificationID" name="ssn"/>
    <property namespace="" localname="PersonName" name="name"/>
    <property namespace="" localname="Address" name="address"/>
  </property-defs>
  <algorithms>
    <!-- config for standard algorithm -->
    <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
      <timestamp path="/es:envelope/es:headers/sm:sources/sm:source/sm:one-first" />
    </std-algorithm>
  </algorithms>
  <merging>
    <merge-strategy name="default-standard" algorithm-ref="standard" max-values="1">
      <source-weights>
        <source name="SOURCE1" weight="10"></source>
      </source-weights>
    </merge-strategy>
    <merge property-name="ssn">
      <source-ref document-uri="docA" />
    </merge>
    <merge property-name="name"  max-values="1">
      <double-metaphone>
        <distance-threshold>50</distance-threshold>
      </double-metaphone>
      <synonyms-support>true</synonyms-support>
      <thesaurus>/mdm/config/thesauri/first-name-synonyms.xml</thesaurus>
      <length weight="8" />
    </merge>
    <merge default="true" strategy="default-standard">
    </merge>
  </merging>
</options>
```