### PR TITLE
Mdm 551: fix error in get-sources affecting JSON data

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -1065,6 +1065,7 @@ declare function merge-impl:get-sources(
     if (fn:exists($ns-path)) then
       map:new(
         for $prefix in fn:in-scope-prefixes($ns-path)
+        where fn:not($prefix = "")
         return
           map:entry($prefix, fn:namespace-uri-for-prefix($prefix, $ns-path))
       )

--- a/src/test/ml-modules/root/test/suites/sorting/get-sources.xqy
+++ b/src/test/ml-modules/root/test/suites/sorting/get-sources.xqy
@@ -1,0 +1,41 @@
+xquery version "1.0-ml";
+
+(:
+ : Get the sources from JSON documents. The last-updated timestamp is in the instance, rather than the headers. We've
+ : seen this come back unpopulated.
+ :)
+
+import module namespace merging = "http://marklogic.com/smart-mastering/merging"
+  at "/com.marklogic.smart-mastering/merging.xqy";
+import module namespace merge-impl = "http://marklogic.com/smart-mastering/survivorship/merging"
+  at "/com.marklogic.smart-mastering/survivorship/merging/base.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+declare function local:assert-correct-source($actual)
+{
+  (
+    test:assert-exists($actual/documentUri),
+    let $doc := fn:doc($actual/documentUri/fn:string())
+    return (
+      test:assert-exists($doc),
+      test:assert-equal($doc/envelope/headers/sources/name/fn:string(), $actual/name/fn:string()),
+      test:assert-equal($doc/envelope/instance/Person/lastModified/fn:string(), $actual/dateTime/fn:string())
+    )
+  )
+};
+
+let $uris := map:keys($lib:TEST-DATA)
+let $docs := $uris ! fn:doc(.)
+let $options := merging:get-options($const:FORMAT-XML)
+let $actual := merge-impl:get-sources($docs, $options)
+return (
+  test:assert-equal(fn:count($uris), fn:count($actual)),
+  for $source in $actual
+  return
+    local:assert-correct-source($source)
+)

--- a/src/test/ml-modules/root/test/suites/sorting/lib/lib.xqy
+++ b/src/test/ml-modules/root/test/suites/sorting/lib/lib.xqy
@@ -1,0 +1,16 @@
+xquery version "1.0-ml";
+
+module namespace lib = "http://marklogic.com/smart-mastering/test";
+
+declare variable $MERGE-OPTIONS-NAME := "test-merge-options";
+
+declare variable $TEST-DATA :=
+  map:new((
+    map:entry("/content/doc1.json", "doc1.json"),
+    map:entry("/content/doc2.json", "doc2.json"),
+    map:entry("/content/doc3.json", "doc3.json"),
+    map:entry("/content/doc4.json", "doc4.json"),
+    map:entry("/content/doc5.json", "doc5.json"),
+    map:entry("/content/doc6.json", "doc6.json"),
+    map:entry("/content/doc7.json", "doc7.json")
+  ));

--- a/src/test/ml-modules/root/test/suites/sorting/setup.xqy
+++ b/src/test/ml-modules/root/test/suites/sorting/setup.xqy
@@ -1,0 +1,20 @@
+xquery version "1.0-ml";
+
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+declare option xdmp:mapping "false";
+
+for $uri in map:keys($lib:TEST-DATA)
+let $doc := test:get-test-file(map:get($lib:TEST-DATA, $uri))
+return
+  xdmp:document-insert(
+    $uri,
+    $doc,
+    xdmp:default-permissions(),
+    $const:CONTENT-COLL
+  )

--- a/src/test/ml-modules/root/test/suites/sorting/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/sorting/suite-setup.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+import module namespace merging = "http://marklogic.com/smart-mastering/merging"
+  at "/com.marklogic.smart-mastering/merging.xqy";
+import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
+
+declare option xdmp:mapping "false";
+
+merging:save-options($lib:MERGE-OPTIONS-NAME, test:get-test-file("merge-options.xml"))

--- a/src/test/ml-modules/root/test/suites/sorting/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/sorting/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+
+xdmp:collection-delete($const:OPTIONS-COLL)

--- a/src/test/ml-modules/root/test/suites/sorting/teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/sorting/teardown.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+
+xdmp:collection-delete($const:CONTENT-COLL)

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc1.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc1.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Hugo",
+        "last_name": "Boldry",
+        "email": "hboldry0@ezinearticles.com",
+        "gender": "Male",
+        "lastModified": "2018-05-25T14:24:36Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc2.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc2.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Gerda",
+        "last_name": "Knutsen",
+        "email": "gknutsen1@wikispaces.com",
+        "gender": "Female",
+        "lastModified": "2018-08-12T10:05:36Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc3.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc3.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Millard",
+        "last_name": "Durand",
+        "email": "mdurand2@histats.com",
+        "gender": "Male",
+        "lastModified": "2018-07-08T00:36:37Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc4.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc4.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Stephanus",
+        "last_name": "Fattore",
+        "email": "sfattore3@examiner.com",
+        "gender": "Male",
+        "lastModified": "2018-03-24T08:17:01Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc5.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc5.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Dorelle",
+        "last_name": "Blondin",
+        "email": "dblondin4@taobao.com",
+        "gender": "Female",
+        "lastModified": "2017-12-29T14:34:57Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc6.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc6.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Chastity",
+        "last_name": "Swanson",
+        "email": "cswanson5@vimeo.com",
+        "gender": "Female",
+        "lastModified": "2018-09-08T04:10:54Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/doc7.json
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/doc7.json
@@ -1,0 +1,21 @@
+{
+  "envelope": {
+    "headers": {
+      "sources": [
+        {
+          "name": "MMIS"
+        }
+      ]
+    },
+    "instance": {
+      "Person": {
+        "ids": "53762077-bf06-4933-be9f-4bf3fb3ad0b0",
+        "first_name": "Reena",
+        "last_name": "Crus",
+        "email": "rcrus6@live.com",
+        "gender": "Female",
+        "lastModified": "2017-10-29T00:40:14Z"
+      }
+    }
+  }
+}

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/match-options.xml
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/match-options.xml
@@ -1,0 +1,22 @@
+<options xmlns="http://marklogic.com/smart-mastering/matcher">
+  <property-defs>
+    <property namespace="" localname="ids" name="id" />
+  </property-defs>
+  <algorithms>
+    <algorithm name="std-reduce" function="standard-reduction"/>
+    <algorithm name="std-reduce-query" function="standard-reduction-query"/>
+    <algorithm name="dbl-metaphone" function="double-metaphone"/>
+    <algorithm name="thesaurus" function="thesaurus"/>
+  </algorithms>
+  <scoring>
+    <add property-name="id" weight="20"/>
+  </scoring>
+  <thresholds>
+    <threshold above="10" label="Definitive Match" action="merge"/>
+    <!-- below 30 will be NOT-A-MATCH or no category -->
+  </thresholds>
+  <tuning>
+    <max-scan>200</max-scan>  <!-- never look at more than 200 -->
+    <initial-scan>20</initial-scan>
+  </tuning>
+</options>

--- a/src/test/ml-modules/root/test/suites/sorting/test-data/merge-options.xml
+++ b/src/test/ml-modules/root/test/suites/sorting/test-data/merge-options.xml
@@ -1,0 +1,27 @@
+<options xmlns="http://marklogic.com/smart-mastering/merging">
+  <match-options>mlw-match</match-options>
+  <property-defs>
+    <property namespace="" localname="ids" name="ids"/>
+    <property namespace="" localname="first_name" name="first_name"/>
+    <property namespace="" localname="last_name" name="last_name"/>
+    <property namespace="" localname="email" name="email"/>
+    <property namespace="" localname="gender" name="gender"/>
+    <property namespace="" localname="lastModified" name="lastModified"/>
+  </property-defs>
+  <algorithms>
+    <std-algorithm xmlns:es="http://marklogic.com/entity-services" xmlns:sm="http://marklogic.com/smart-mastering">
+      <!-- provide the path to the timestamp element to use for sorting -->
+      <!-- when merging the values are sorted in recency order from newest
+           to oldest based on this timestamp. If the timestamp is not
+           provided then there is no recency sort -->
+      <timestamp path="/envelope/instance/Person/lastModified" />
+    </std-algorithm>
+  </algorithms>
+  <merging>
+    <merge property-name="ids" max-values="1" />
+    <merge property-name="first_name" max-values="1" />
+    <merge property-name="last_name" max-values="1" />
+    <merge property-name="email" max-values="1" />
+    <merge property-name="gender" max-values="1" />
+  </merging>
+</options>


### PR DESCRIPTION
We had one case of building a namespace map that didn't have the `where fn:not($prefix = "")` clause. That omission caused an error. 