### PR TITLE
Mdm 575: make matching function names consistent with merging names

### DIFF
--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/impl/process.xqy
@@ -64,7 +64,7 @@ declare function proc-impl:process-match-and-merge-with-options(
   tel:increment(),
 
   let $_ := xdmp:trace($const:TRACE-MATCH-RESULTS, "processing: " || $uri)
-  let $matching-options := matcher:get-options-as-xml(fn:string($options/merging:match-options))
+  let $matching-options := matcher:get-options(fn:string($options/merging:match-options), $const:FORMAT-XML)
   let $thresholds := $matching-options/matcher:thresholds/matcher:threshold[@action = ($const:MERGE-ACTION, $const:NOTIFY-ACTION)]
   let $threshold-labels := $thresholds/@label
   let $minimum-threshold :=

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher.xqy
@@ -58,7 +58,7 @@ as element(results)
 {
   matcher:find-document-matches-by-options(
     $document,
-    matcher:get-options-as-xml($options-name),
+    matcher:get-options($options-name, $const:FORMAT-XML),
     fn:false(),
     cts:true-query()
   )
@@ -84,7 +84,12 @@ declare function matcher:find-document-matches-by-options-name(
 )
   as element(results)
 {
-  matcher:find-document-matches-by-options($document, matcher:get-options-as-xml($options-name), $include-matches, $filter-query)
+  matcher:find-document-matches-by-options(
+    $document,
+    matcher:get-options($options-name, $const:FORMAT-XML),
+    $include-matches,
+    $filter-query
+  )
 };
 
 (:
@@ -202,6 +207,36 @@ declare function matcher:results-to-json($results-xml)
 (:
  : Retrieve names of all previously saved matcher options.
  :
+ : @param $format  either $const:FORMAT-XML or $const:FORMAT-JSON
+ : @return  <matcher:options> element containing zero or more <matcher:option> elements
+ :)
+declare function matcher:get-option-names($format as xs:string)
+{
+  if ($format = $const:FORMAT-XML) then
+    opt-impl:get-option-names-as-xml()
+  else
+    opt-impl:get-option-names-as-json()
+};
+
+(:
+ : Retrieve names of all previously saved matcher options.
+ :
+ : @param $options-name  the name under which the options were saved
+ : @param $format  either $const:FORMAT-XML or $const:FORMAT-JSON
+ : @return  <matcher:options> element containing zero or more <matcher:option> elements
+ :)
+declare function matcher:get-options($options-name as xs:string, $format as xs:string)
+{
+  if ($format = $const:FORMAT-XML) then
+    opt-impl:get-options-as-xml($options-name)
+  else
+    opt-impl:get-options-as-json($options-name)
+};
+
+(:
+ : Retrieve names of all previously saved matcher options.
+ : @deprecated call `matcher:get-option-names($const:FORMAT-XML)` instead
+ :
  : @return  <matcher:options> element containing zero or more <matcher:option> elements
  :)
 declare function matcher:get-option-names-as-xml()
@@ -212,6 +247,7 @@ declare function matcher:get-option-names-as-xml()
 
 (:
  : Retrieve names of all previously saved matcher options.
+ : @deprecated call `matcher:get-option-names($const:FORMAT-JSON)` instead
  :
  : @return  JSON array of strings
  :)
@@ -221,12 +257,18 @@ declare function matcher:get-option-names-as-json()
   opt-impl:get-option-names-as-json()
 };
 
+(:
+ : @deprecated call `matcher:get-options($options-name, $const:FORMAT-XML)` instead
+ :)
 declare function matcher:get-options-as-xml($options-name as xs:string)
   as element(matcher:options)?
 {
   opt-impl:get-options-as-xml($options-name)
 };
 
+(:
+ : @deprecated call `matcher:get-options($options-name, $const:FORMAT-JSON)` instead
+ :)
 declare function matcher:get-options-as-json($options-name as xs:string)
   as object-node()?
 {

--- a/src/main/ml-modules/services/sm-match-option-names.xqy
+++ b/src/main/ml-modules/services/sm-match-option-names.xqy
@@ -4,6 +4,8 @@ module namespace resource = "http://marklogic.com/rest-api/resource/sm-match-opt
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
 
 declare function get(
   $context as map:map,
@@ -11,6 +13,6 @@ declare function get(
   ) as document-node()*
 {
   document {
-    matcher:get-option-names-as-json()
+    matcher:get-option-names($const:FORMAT-JSON)
   }
 };

--- a/src/main/ml-modules/services/sm-match-options.xqy
+++ b/src/main/ml-modules/services/sm-match-options.xqy
@@ -4,6 +4,8 @@ module namespace resource = "http://marklogic.com/rest-api/resource/sm-match-opt
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
 
 declare namespace rapi = "http://marklogic.com/rest-api";
 
@@ -14,7 +16,7 @@ declare function get(
 {
   if (map:contains($params, "name")) then
     document {
-      matcher:get-options-as-json(map:get($params, "name"))
+      matcher:get-options(map:get($params, "name"), $const:FORMAT-JSON)
     }
   else
     fn:error((),"RESTAPI-SRVEXERR",

--- a/src/main/ml-modules/services/sm-match.xqy
+++ b/src/main/ml-modules/services/sm-match.xqy
@@ -4,6 +4,8 @@ module namespace resource = "http://marklogic.com/rest-api/resource/sm-match";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
 
 declare namespace rapi = "http://marklogic.com/rest-api";
 
@@ -49,7 +51,7 @@ function post(
     else ()
   let $options :=
     if (map:contains($params, "options")) then
-      matcher:get-options-as-xml(map:get($params, "options"))
+      matcher:get-options(map:get($params, "options"), $const:FORMAT-XML)
     else
       $input-root/(element(matcher:options)|self::object-node()[object-node("options")])
   let $_options-check :=

--- a/src/test/ml-modules/root/test/suites/double-metaphone/db-initialize.xqy
+++ b/src/test/ml-modules/root/test/suites/double-metaphone/db-initialize.xqy
@@ -2,8 +2,6 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
-  at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
 import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";

--- a/src/test/ml-modules/root/test/suites/match-and-merge/duplicate-match.xqy
+++ b/src/test/ml-modules/root/test/suites/match-and-merge/duplicate-match.xqy
@@ -2,8 +2,6 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
-  at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace process = "http://marklogic.com/smart-mastering/process-records"
   at "/com.marklogic.smart-mastering/process-records.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";

--- a/src/test/ml-modules/root/test/suites/matching-json/match-response.xqy
+++ b/src/test/ml-modules/root/test/suites/matching-json/match-response.xqy
@@ -2,7 +2,7 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
@@ -11,7 +11,7 @@ import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test
 declare option xdmp:mapping "false";
 
 let $doc := fn:doc($lib:URI2)
-let $options := matcher:get-options-as-xml($lib:MATCH-OPTIONS-NAME)
+let $options := matcher:get-options($lib:MATCH-OPTIONS-NAME, $const:FORMAT-XML)
 return (
   (: test page length gt # of results :)
   let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 6, fn:true(), cts:true-query())

--- a/src/test/ml-modules/root/test/suites/matching-json/scoring.xqy
+++ b/src/test/ml-modules/root/test/suites/matching-json/scoring.xqy
@@ -2,7 +2,7 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
@@ -11,7 +11,7 @@ import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test
 declare option xdmp:mapping "false";
 
 let $doc := fn:doc($lib:URI2)
-let $options := matcher:get-options-as-xml($lib:SCORE-OPTIONS-NAME)
+let $options := matcher:get-options($lib:SCORE-OPTIONS-NAME, $const:FORMAT-XML)
 let $max-score := fn:sum($options//*:add/@weight)
 let $actual := matcher:find-document-matches-by-options-name($doc, $lib:SCORE-OPTIONS-NAME)
 let $score := $actual//result[@uri=$lib:URI3]/@score/xs:int(.)
@@ -20,7 +20,7 @@ return (
 ),
 
 let $doc := fn:doc($lib:URI2)
-let $options := matcher:get-options-as-xml($lib:SCORE-OPTIONS-NAME2)
+let $options := matcher:get-options($lib:SCORE-OPTIONS-NAME2, $const:FORMAT-XML)
 let $max-score := fn:sum($options//*:add/@weight)
 let $actual := matcher:find-document-matches-by-options-name($doc, $lib:SCORE-OPTIONS-NAME2)
 let $score := $actual//result[@uri=$lib:URI3]/@score/xs:int(.)

--- a/src/test/ml-modules/root/test/suites/matching/match-response.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/match-response.xqy
@@ -2,7 +2,7 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
@@ -101,7 +101,7 @@ declare option xdmp:mapping "false";
  :)
 
 let $doc := fn:doc($lib:URI2)
-let $options := matcher:get-options-as-xml($lib:MATCH-OPTIONS-NAME)
+let $options := matcher:get-options($lib:MATCH-OPTIONS-NAME, $const:FORMAT-XML)
 return (
   (: test page length gt # of results :)
   let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 6, fn:true(), cts:true-query())

--- a/src/test/ml-modules/root/test/suites/matching/namespaced-match-response.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/namespaced-match-response.xqy
@@ -2,7 +2,7 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
@@ -92,7 +92,7 @@ declare option xdmp:mapping "false";
  :)
 
 let $doc := fn:doc($lib:NAMESPACED-URI2)
-let $options := matcher:get-options-as-xml($lib:NAMESPACED-MATCH-OPTIONS-NAME)
+let $options := matcher:get-options($lib:NAMESPACED-MATCH-OPTIONS-NAME, $const:FORMAT-XML)
 return (
   (: test page length gt # of results :)
   let $actual := matcher:find-document-matches-by-options($doc, $options, 1, 6, fn:true(), cts:true-query())

--- a/src/test/ml-modules/root/test/suites/matching/scoring.xqy
+++ b/src/test/ml-modules/root/test/suites/matching/scoring.xqy
@@ -2,7 +2,7 @@ xquery version "1.0-ml";
 
 import module namespace matcher = "http://marklogic.com/smart-mastering/matcher"
   at "/com.marklogic.smart-mastering/matcher.xqy";
-import module namespace constants = "http://marklogic.com/smart-mastering/constants"
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
   at "/com.marklogic.smart-mastering/constants.xqy";
 import module namespace lib = "http://marklogic.com/smart-mastering/test" at "lib/lib.xqy";
 
@@ -11,7 +11,7 @@ import module namespace test = "http://marklogic.com/roxy/test-helper" at "/test
 declare option xdmp:mapping "false";
 
 let $doc := fn:doc($lib:URI2)
-let $options := matcher:get-options-as-xml($lib:SCORE-OPTIONS-NAME)
+let $options := matcher:get-options($lib:SCORE-OPTIONS-NAME, $const:FORMAT-XML)
 let $max-score := fn:sum($options//*:add/@weight)
 let $actual := matcher:find-document-matches-by-options-name($doc, $lib:SCORE-OPTIONS-NAME)
 let $score := $actual//result[@uri="/source/3/doc3.xml"]/@score/xs:int(.)
@@ -20,7 +20,7 @@ return (
 ),
 
 let $doc := fn:doc($lib:URI2)
-let $options := matcher:get-options-as-xml($lib:SCORE-OPTIONS-NAME2)
+let $options := matcher:get-options($lib:SCORE-OPTIONS-NAME2, $const:FORMAT-XML)
 let $max-score := fn:sum($options//*:add/@weight)
 let $actual := matcher:find-document-matches-by-options-name($doc, $lib:SCORE-OPTIONS-NAME2)
 let $score := $actual//result[@uri="/source/3/doc3.xml"]/@score/xs:int(.)


### PR DESCRIPTION
- added functions with consistent naming convention
- labeled the old functions `@deprecated` (but kept them to avoid a breaking change)
- updated all references to use the new functions