### PR TITLE
Add mlcp options file for push to globalsearch.marklogic.com

### DIFF
--- a/load-to-globalsearch.mlcp
+++ b/load-to-globalsearch.mlcp
@@ -1,0 +1,36 @@
+#-----------------------------------------------------------------------------#
+# An mlcp option file to push the _pages folder into the global search dhf
+# instance. Use as follows (assumes mlcp as a globally configured executable):
+#
+# mlcp -options_file load-to-globalsearch.mlcp -username user -password pass
+#
+# Use your network credentials for `user` and `pass`. VPN connection is
+# required if outside the company network.
+#-----------------------------------------------------------------------------#
+import
+-input_file_path
+_pages/*
+-document_type
+text
+-output_uri_replace
+".*/smart-mastering-core,'/smart-mastering-core'"
+-fastload
+false
+-host
+globalsearch.marklogic.com
+-port
+8011
+-modules_root
+/
+-transform_module
+"/MarkLogic/data-hub-framework/transforms/mlcp-flow-transform.xqy"
+-transform_namespace
+"http://marklogic.com/data-hub/mlcp-flow-transform"
+-transform_param
+'entity-name=WebDocument,flow-name=loadGithubPages,options={"base-url":"https://marklogic-community.github.io/smart-mastering-core"}'
+-output_collections
+"WebDocument,loadGithubPages,input,category/guide"
+-output_permissions
+"rest-reader,read,rest-writer,update"
+-mode
+local


### PR DESCRIPTION
This is an mlcp option file to load the documentation as part of the globalsearch initiative. Not meant to be part of main branch nor released.

Targetted towards the docs branch.