### PR TITLE
Mdm 516: Add match-and-merge service; update dhf-flow example to use it

### DIFF
--- a/examples/dhf-flow/build.gradle
+++ b/examples/dhf-flow/build.gradle
@@ -284,7 +284,9 @@ task setupExample {
   dependsOn loadCode
 }
 
-task runPersonMastering(type: com.marklogic.gradle.task.RunFlowTask) {
+// The MDM entity's SmartMaster flow has a collector. Tell the sm-match-and-merge endpoint to call that collector and
+// process the URIs it identifies. All of those URIs will be run in a single transaction.
+task runPersonMastering(type: com.marklogic.gradle.task.client.CallResourceTask) {
   mustRunAfter importThesauri
   mustRunAfter deployMatchOptions
   mustRunAfter deployMergeOptions
@@ -296,13 +298,22 @@ task runPersonMastering(type: com.marklogic.gradle.task.RunFlowTask) {
   mustRunAfter loadCode
   mustRunAfter setupExample
 
-  entityName = "MDM"
-  flowName = "SmartMaster"
-  batchSize = 100
-  threadCount = 4
+  client = hubConfig.newFinalClient()
+  resourceName = 'sm-match-and-merge'
+  method = 'POST'
+  body = []
+  params = [
+    'collector-name': 'collect',
+    'collector-name': 'collect',
+    'collector-ns': 'http://marklogic.com/data-hub/plugins',
+    'collector-at': '/entities/MDM/harmonize/SmartMaster/collector.xqy',
+    'options': 'mdm-merge-options',
+    'query': '<cts:collection-query xmlns:cts=\"http://marklogic.com/cts\"><cts:uri>MDM</cts:uri></cts:collection-query>'
+  ]
 }
 
-task runOrgMastering(type: com.marklogic.gradle.task.RunFlowTask) {
+// Same as runPersonMastering, but for the Orgnization entity.
+task runOrgMastering(type: com.marklogic.gradle.task.client.CallResourceTask) {
   mustRunAfter importThesauri
   mustRunAfter deployMatchOptions
   mustRunAfter deployMergeOptions
@@ -314,12 +325,17 @@ task runOrgMastering(type: com.marklogic.gradle.task.RunFlowTask) {
   mustRunAfter loadCode
   mustRunAfter setupExample
 
-  entityName = "Organization"
-  flowName = "SmartMaster"
-  sourceDB = "data-hub-FINAL"
-  destDB = "data-hub-FINAL"
-  batchSize = 100
-  threadCount = 4
+  client = hubConfig.newFinalClient()
+  resourceName = 'sm-match-and-merge'
+  method = 'POST'
+  body = []
+  params = [
+    'collector-name': 'collect',
+    'collector-name': 'collect',
+    'collector-at': '/entities/Organization/harmonize/SmartMaster/collector.sjs',
+    'options': 'org-merge-options',
+    'query': '<cts:collection-query xmlns:cts=\"http://marklogic.com/cts\"><cts:uri>Organization</cts:uri></cts:collection-query>'
+  ]
 }
 
 // a convenience task to run the Smart Mastering flow

--- a/examples/dhf-flow/plugins/entities/Organization/harmonize/SmartMaster/collector.sjs
+++ b/examples/dhf-flow/plugins/entities/Organization/harmonize/SmartMaster/collector.sjs
@@ -1,3 +1,6 @@
+
+const con = require("/com.marklogic.smart-mastering/constants.xqy");
+
 /*
  * Collect IDs plugin
  *
@@ -7,7 +10,7 @@
  */
 function collect(options) {
   // by default we return the URIs in the same collection as the Entity name
-  return cts.uris(null, null, cts.collectionQuery(options.entity));
+  return cts.uris(null, null, cts.collectionQuery(con['CONTENT-COLL']));
 }
 
 module.exports = {

--- a/examples/dhf-flow/src/main/ml-config/security/roles/mdm-user.json
+++ b/examples/dhf-flow/src/main/ml-config/security/roles/mdm-user.json
@@ -19,6 +19,11 @@
       "kind": "execute"
     },
     {
+      "privilege-name": "sem:sparql",
+      "action": "http://marklogic.com/xdmp/privileges/sem-sparql",
+      "kind": "execute"
+    },
+    {
       "privilege-name": "xdbc:eval",
       "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
       "kind": "execute"
@@ -51,6 +56,11 @@
     {
       "privilege-name": "xdmp:spawn",
       "action": "http://marklogic.com/xdmp/privileges/xdmp-spawn",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "xslt:eval",
+      "action": "http://marklogic.com/xdmp/privileges/xslt-eval",
       "kind": "execute"
     }
   ]

--- a/src/main/ml-modules/services/metadata/sm-match-and-merge.xml
+++ b/src/main/ml-modules/services/metadata/sm-match-and-merge.xml
@@ -1,0 +1,30 @@
+<metadata>
+  <title>Smart Mastering: Match and Merge</title>
+  <description>
+    <p>Run matching against documents, then execute the actions</p>
+    <dl>
+      <dt>POST</dt>
+      <dd>
+        <dl>
+          <dt>Parameters</dt>
+          <dd>
+            <ul>
+              <li>rs:uri (xs:string*)</li>
+              <li>rs:collector-name (xs:string?)</li>
+              <li>rs:collector-ns (xs:string?)</li>
+              <li>rs:collector-at (xs:string?)</li>
+              <li>rs:options (xs:string)</li>
+            </ul>
+          </dd>
+        </dl>
+      </dd>
+    </dl>
+  </description>
+  <method name="POST">
+    <param name="uri" type="xs:string*" />
+    <param name="rs:collector-name" type="xs:string?" />
+    <param name="rs:collector-ns" type="xs:string?" />
+    <param name="rs:collector-at" type="xs:string?" />
+    <param name="options" type="xs:string" />
+  </method>
+</metadata>

--- a/src/main/ml-modules/services/sm-match-and-merge.xqy
+++ b/src/main/ml-modules/services/sm-match-and-merge.xqy
@@ -1,0 +1,79 @@
+xquery version "1.0-ml";
+
+module namespace resource = "http://marklogic.com/rest-api/resource/sm-match-and-merge";
+
+import module namespace process = "http://marklogic.com/smart-mastering/process-records"
+  at "/com.marklogic.smart-mastering/process-records.xqy";
+import module namespace const = "http://marklogic.com/smart-mastering/constants"
+  at "/com.marklogic.smart-mastering/constants.xqy";
+
+declare namespace rapi = "http://marklogic.com/rest-api";
+
+declare option xdmp:mapping "false";
+
+declare function resource:get-collector($params as map:map)
+{
+  let $collector-at := map:get($params, "collector-at")
+  let $collector-ns := map:get($params, "collector-ns")
+  let $collector-name := map:get($params, "collector-name")
+  return
+    if (fn:empty($collector-name)) then
+      (: Caller wasn't trying to load a collector :)
+      ()
+    else
+      (: Will thrown XDMP-MODNOTFOUND if the parameters don't point to a function. Try/catch does not catch that exception. :)
+      xdmp:function(fn:QName($collector-ns, $collector-name), $collector-at)
+};
+
+declare
+%rapi:transaction-mode("update")
+function post(
+  $context as map:map,
+  $params  as map:map,
+  $input   as document-node()*
+  ) as document-node()*
+{
+  let $collector := resource:get-collector($params)
+  let $uris :=
+    if (fn:exists($collector)) then
+      xdmp:apply($collector, map:map())
+    else
+      map:get($params, "uri")
+  let $options-name :=
+    let $name := map:get($params, "options")
+    return
+      if (fn:exists($name)) then
+        $name
+      else
+        fn:error((),"RESTAPI-SRVEXERR",
+          (400, "Bad Request",
+          "'options' is a required parameter"))
+  let $query :=
+    let $q := map:get($params, "query")
+    return
+      if (fn:exists($q)) then
+        try {
+          cts:query(xdmp:unquote($q)/node())
+        }
+        catch ($e) {
+          if ($e/error:code = "XDMP-NOTQUERY") then
+            fn:error((),"RESTAPI-SRVEXERR",
+              (400, "Bad Request",
+              "'query' must be a serialized query; got " || $q))
+          else
+            xdmp:rethrow()
+        }
+      else ()
+  return (
+    if (xdmp:trace-enabled($const:TRACE-MATCH-RESULTS)) then
+      xdmp:trace($const:TRACE-MATCH-RESULTS, "Calling process-match-and-merge with URIs [" ||
+        fn:string-join($uris, "; ") ||
+        "], options name=" || $options-name ||
+        ", and query=" || xdmp:quote($query))
+    else (),
+    if (fn:exists($query)) then
+      document { process:process-match-and-merge($uris, $options-name, $query) }
+    else
+      document { process:process-match-and-merge($uris, $options-name) }
+  )
+};


### PR DESCRIPTION
This PR updates the dhf-flow example to use a new `sm-match-and-merge` service and calls `process-match-and-merge` with a sequence of URIs. 

A TODO is to support batching. 