### PR TITLE
Remove roles

### DIFF
--- a/src/main/ml-config/security/roles/mdm-admin.json
+++ b/src/main/ml-config/security/roles/mdm-admin.json
@@ -1,5 +1,0 @@
-{
-  "role-name": "mdm-admin",
-  "description": "Smart Mastering admin role",
-  "role": ["admin", "rest-admin"]
-}

--- a/src/main/ml-config/security/roles/mdm-user.json
+++ b/src/main/ml-config/security/roles/mdm-user.json
@@ -1,5 +1,0 @@
-{
-  "role-name": "mdm-user",
-  "description": "Smart Mastering user role",
-  "role": ["rest-reader", "rest-writer"]
-}

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/algorithms/double-metaphone.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/algorithms/double-metaphone.xqy
@@ -103,7 +103,7 @@ declare function algorithms:setup-double-metaphone($expand-xml, $options-xml, $o
               xdmp:log("Caught an error while generating double-metaphone dictionary: " || xdmp:quote($e), "error")
             }
           ),
-          (xdmp:permission($const:MDM-ADMIN, "update"), xdmp:permission($const:MDM-USER, "read")),
+          xdmp:default-permissions(),
           ($const:OPTIONS-COLL, $const:DICTIONARY-COLL)
         )
       },

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/auditing/base.xqy
@@ -170,11 +170,7 @@ declare function auditing:audit-trace(
         $prov-xml/node(),
         auditing:build-semantic-info($prov-xml)
       },
-      (
-        xdmp:default-permissions(),
-        xdmp:permission($const:MDM-USER, "read"),
-        xdmp:permission($const:MDM-ADMIN, "update")
-      ),
+      xdmp:default-permissions(),
       $const:AUDITING-COLL
     )
 };
@@ -406,11 +402,7 @@ declare function auditing:build-semantic-info($prov-xml as element(prov:document
       sem:graph-insert(
         sem:iri("mdm-auditing"),
         $auditing-managed-triples,
-        (
-          xdmp:default-permissions(),
-          xdmp:permission($const:MDM-USER, "read"),
-          xdmp:permission($const:MDM-ADMIN, "update")
-        ),
+        xdmp:default-permissions(),
         $const:AUDITING-COLL
       )
     else (),

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/constants.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/constants.xqy
@@ -28,10 +28,6 @@ declare variable $MODEL-MAPPER-COLL as xs:string := "mdm-model-mapper";
 declare variable $NOTIFICATION-COLL as xs:string := "mdm-notification";
 declare variable $OPTIONS-COLL as xs:string := "mdm-options";
 
-(: Roles :)
-declare variable $MDM-USER as xs:string := "mdm-user";
-declare variable $MDM-ADMIN as xs:string := "mdm-admin";
-
 (: Actions :)
 declare variable $MERGE-ACTION as xs:string := "merge";
 declare variable $NOTIFY-ACTION as xs:string := "notify";

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/notification-impl.xqy
@@ -81,11 +81,7 @@ declare function notify-impl:save-match-notification(
       xdmp:document-insert(
         $notification-uri,
         $new-notification,
-        (
-          xdmp:default-permissions(),
-          xdmp:permission($const:MDM-USER, "read"),
-          xdmp:permission($const:MDM-USER, "update")
-        ),
+        xdmp:default-permissions(),
         coll-impl:on-notification(
           map:map(),
           $options/merging:algorithms/merging:collections/merging:on-notification

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/matcher-impl/options-impl.xqy
@@ -126,7 +126,7 @@ declare function opt-impl:save-options(
     xdmp:document-insert(
       $ALGORITHM-OPTIONS-DIR||$name||".xml",
       $options,
-      (xdmp:permission($const:MDM-ADMIN, "update"), xdmp:permission($const:MDM-USER, "read")),
+      xdmp:default-permissions(),
       ($const:OPTIONS-COLL, $const:MATCH-OPTIONS-COLL, $const:ALGORITHM-COLL)
     )
   )

--- a/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
+++ b/src/main/ml-modules/root/com.marklogic.smart-mastering/survivorship/merging/base.xqy
@@ -239,8 +239,7 @@ declare function merge-impl:save-merge-models-by-uri(
           $merge-uri,
           $merged-document,
           (
-            xdmp:permission($const:MDM-ADMIN, "update"),
-            xdmp:permission($const:MDM-USER, "read"),
+            xdmp:default-permissions(),
             fn:map(xdmp:document-get-permissions#1, $uris)
           ),
           coll-impl:on-merge(map:new((
@@ -1873,7 +1872,7 @@ declare function merge-impl:save-options(
     xdmp:document-insert(
       $MERGING-OPTIONS-DIR||$name||".xml",
       $options,
-      (xdmp:permission($const:MDM-ADMIN, "update"), xdmp:permission($const:MDM-USER, "read")),
+      xdmp:default-permissions(),
       ($const:OPTIONS-COLL, $const:MERGE-OPTIONS-COLL)
     )
 };


### PR DESCRIPTION
This PR removes the MDM-ADMIN and MDM-USER roles.

Removing the roles simplifies the deployment of Smart Mastering. It puts the burden of creating least-privilege roles and users on the end user instead of forcing them to user our pre-canned roles.